### PR TITLE
Integrate write-ahead log into LSM tree

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 use std::{net::SocketAddr, sync::Arc};
 
-use axum::{extract::State, http::StatusCode, routing::post, Router};
+use axum::{Router, extract::State, http::StatusCode, routing::post};
 use clap::{Parser, ValueEnum};
 use lsmt::{
-    storage::{local::LocalStorage, s3::S3Storage, Storage},
     Database, SqlEngine,
+    storage::{Storage, local::LocalStorage, s3::S3Storage},
 };
 
-type DynStorage = Box<dyn Storage>;
+type DynStorage = Arc<dyn Storage>;
 
 #[derive(Parser)]
 struct Args {
@@ -26,16 +26,10 @@ enum StorageKind {
 }
 
 /// Handle incoming SQL queries sent to the server.
-async fn handle_query(
-    State(db): State<Arc<Database<DynStorage>>>,
-    body: String,
-) -> (StatusCode, String) {
+async fn handle_query(State(db): State<Arc<Database>>, body: String) -> (StatusCode, String) {
     let engine = SqlEngine::new();
     match engine.execute(&db, &body).await {
-        Ok(Some(bytes)) => (
-            StatusCode::OK,
-            String::from_utf8_lossy(&bytes).to_string(),
-        ),
+        Ok(Some(bytes)) => (StatusCode::OK, String::from_utf8_lossy(&bytes).to_string()),
         Ok(None) => (StatusCode::OK, String::new()),
         Err(e) => (StatusCode::BAD_REQUEST, e.to_string()),
     }
@@ -47,21 +41,21 @@ async fn main() {
     let args = Args::parse();
 
     let storage: DynStorage = match args.storage {
-        StorageKind::Local => Box::new(LocalStorage::new(args.data_dir)),
+        StorageKind::Local => Arc::new(LocalStorage::new(&args.data_dir)),
         StorageKind::S3 => {
-            let bucket = args
-                .bucket
-                .expect("--bucket required for s3 storage mode");
-            Box::new(
+            let bucket = args.bucket.expect("--bucket required for s3 storage mode");
+            Arc::new(
                 S3Storage::new(&bucket)
                     .await
                     .expect("failed to create s3 storage"),
             )
         }
     };
-    let db = Arc::new(Database::new(storage));
+    let db = Arc::new(Database::new(storage, "wal.log").await);
 
-    let app = Router::new().route("/query", post(handle_query)).with_state(db);
+    let app = Router::new()
+        .route("/query", post(handle_query))
+        .with_state(db);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
     println!("LSMT server listening on {addr}");

--- a/src/sstable.rs
+++ b/src/sstable.rs
@@ -1,8 +1,8 @@
 use crate::bloom::BloomFilter;
 use crate::storage::{Storage, StorageError};
 use crate::zonemap::ZoneMap;
-use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 
 // field delimiters within on-disk table files
 const SEP: u8 = b'\t';
@@ -31,7 +31,7 @@ impl SsTable {
 
     /// Write a new table to disk from the provided `entries` and return
     /// the constructed [`SsTable`] metadata.
-    pub async fn create<S: Storage + Sync + Send>(
+    pub async fn create<S: Storage + Sync + Send + ?Sized>(
         path: impl Into<String>,
         entries: &[(String, Vec<u8>)],
         storage: &S,
@@ -52,12 +52,16 @@ impl SsTable {
             data.push(NL);
         }
         storage.put(&path, data).await?;
-        Ok(Self { path, bloom, zone_map })
+        Ok(Self {
+            path,
+            bloom,
+            zone_map,
+        })
     }
 
     /// Retrieve a value from the table, consulting bloom filter and zone
     /// map before scanning the file.
-    pub async fn get<S: Storage + Sync + Send>(
+    pub async fn get<S: Storage + Sync + Send + ?Sized>(
         &self,
         key: &str,
         storage: &S,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::sync::Arc;
 
 #[async_trait]
 pub trait Storage: Send + Sync {
@@ -8,6 +9,17 @@ pub trait Storage: Send + Sync {
 
 #[async_trait]
 impl Storage for Box<dyn Storage> {
+    async fn put(&self, path: &str, data: Vec<u8>) -> Result<(), StorageError> {
+        (**self).put(path, data).await
+    }
+
+    async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
+        (**self).get(path).await
+    }
+}
+
+#[async_trait]
+impl Storage for Arc<dyn Storage> {
     async fn put(&self, path: &str, data: Vec<u8>) -> Result<(), StorageError> {
         (**self).put(path, data).await
     }

--- a/tests/e2e_local.rs
+++ b/tests/e2e_local.rs
@@ -1,10 +1,14 @@
-use lsmt::{storage::local::LocalStorage, Database, SqlEngine};
+use lsmt::{
+    Database, SqlEngine,
+    storage::{Storage, local::LocalStorage},
+};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn e2e_insert_select() {
     let dir = tempfile::tempdir().unwrap();
-    let storage = LocalStorage::new(dir.path());
-    let db = Database::new(storage);
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
+    let db = Database::new(storage, "wal.log").await;
     let engine = SqlEngine::new();
     engine
         .execute(&db, "INSERT INTO kv VALUES ('foo','bar')")

--- a/tests/lsm_flush_test.rs
+++ b/tests/lsm_flush_test.rs
@@ -1,10 +1,14 @@
-use lsmt::{Database, storage::local::LocalStorage};
+use lsmt::{
+    Database,
+    storage::{Storage, local::LocalStorage},
+};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn flush_and_query_from_sstable() {
     let dir = tempfile::tempdir().unwrap();
-    let storage = LocalStorage::new(dir.path());
-    let db = Database::new(storage);
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
+    let db = Database::new(storage, "wal.log").await;
 
     db.insert("k1".to_string(), b"v1".to_vec()).await;
     db.insert("k2".to_string(), b"v2".to_vec()).await;

--- a/tests/wal_recovery_test.rs
+++ b/tests/wal_recovery_test.rs
@@ -1,0 +1,20 @@
+use lsmt::{
+    Database,
+    storage::{Storage, local::LocalStorage},
+};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn wal_recovery_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let wal = "wal.log";
+    {
+        let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
+        let db = Database::new(storage, wal).await;
+        db.insert("k1".to_string(), b"v1".to_vec()).await;
+    }
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
+    let db = Database::new(storage, wal).await;
+    assert_eq!(db.get("k1").await, Some(b"v1".to_vec()));
+}


### PR DESCRIPTION
## Summary
- persist writes to a simple WAL and replay them on startup
- clear WAL after flushing memtable to SSTable
- wire the server and tests to use the WAL and add recovery test
- store WAL in the configured storage backend so S3 deployments persist the log alongside SSTables

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e2d4a78208324a5152f84b7e94087