### PR TITLE
Implement timestamped mutations with LWW conflict resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1000,6 +1000,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "clap",
+ "murmur3",
  "reqwest 0.11.27",
  "rust-s3",
  "serde",
@@ -1064,6 +1065,12 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "num-conv"
@@ -1462,7 +1469,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ rust-s3 = { version = "0.36.0-beta.2", default-features = false, features = ["to
 axum = "0.7"
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+murmur3 = "0.5"
 
 [dev-dependencies]
 tempfile = "3"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,0 +1,243 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    io::Cursor,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use murmur3::murmur3_32;
+use reqwest::Client;
+
+use crate::{Database, SqlEngine, query::QueryError};
+use sqlparser::ast::{ObjectType, Statement};
+
+/// Simple cluster management and request coordination.
+///
+/// This implementation provides a very lightweight rendition of a
+/// peer-to-peer ring with configurable replication.  Nodes are
+/// identified by their base HTTP address (e.g. `http://127.0.0.1:8080`).
+/// Each node owns a number of virtual nodes on the ring in order to
+/// balance load.  Requests are replicated to the selected peers based on
+/// a Murmur3 hash of the incoming statement.
+pub struct Cluster {
+    db: Arc<Database>,
+    ring: BTreeMap<u32, String>,
+    rf: usize,
+    client: Client,
+    self_addr: String,
+}
+
+impl Cluster {
+    /// Create a new cluster coordinator.
+    pub fn new(
+        db: Arc<Database>,
+        self_addr: String,
+        mut peers: Vec<String>,
+        vnodes: usize,
+        rf: usize,
+    ) -> Self {
+        peers.push(self_addr.clone());
+        let mut ring = BTreeMap::new();
+        for node in peers.iter() {
+            for v in 0..vnodes.max(1) {
+                let token_key = format!("{}-{}", node, v);
+                let mut cursor = Cursor::new(token_key.as_bytes());
+                let token = murmur3_32(&mut cursor, 0).unwrap();
+                ring.insert(token, node.clone());
+            }
+        }
+        Self {
+            db,
+            ring,
+            rf: rf.max(1),
+            client: Client::new(),
+            self_addr,
+        }
+    }
+
+    fn replicas_for(&self, key: &str) -> Vec<String> {
+        let mut cursor = Cursor::new(key.as_bytes());
+        let token = murmur3_32(&mut cursor, 0).unwrap();
+        let mut reps = Vec::new();
+        for (_k, node) in self.ring.range(token..) {
+            if !reps.contains(node) {
+                reps.push(node.clone());
+            }
+            if reps.len() == self.rf {
+                return reps;
+            }
+        }
+        for (_k, node) in &self.ring {
+            if !reps.contains(node) {
+                reps.push(node.clone());
+            }
+            if reps.len() == self.rf {
+                break;
+            }
+        }
+        reps
+    }
+
+    /// Execute `sql` against the appropriate replicas.
+    ///
+    /// When `forwarded` is false the current node acts as the coordinator
+    /// and forwards the statement to the replica nodes determined by the
+    /// partition key.  Results from all replicas are unioned together and
+    /// returned to the caller.  When `forwarded` is true the query is being
+    /// handled on behalf of a peer and is executed locally without further
+    /// replication.
+    pub async fn execute(&self, sql: &str, forwarded: bool) -> Result<Option<Vec<u8>>, QueryError> {
+        let engine = SqlEngine::new();
+        if forwarded {
+            let (ts, real_sql) = if let Some(rest) = sql.strip_prefix("--ts:") {
+                if let Some(pos) = rest.find('\n') {
+                    let ts = rest[..pos].parse().unwrap_or(0);
+                    (ts, &rest[pos + 1..])
+                } else {
+                    (0, sql)
+                }
+            } else {
+                (0, sql)
+            };
+            return engine.execute_with_ts(&self.db, real_sql, ts, true).await;
+        }
+
+        // Determine if the statement is a schema mutation that should be
+        // broadcast to every node and whether it is a write.
+        let mut broadcast = false;
+        let mut is_write = false;
+        if let Ok(stmts) = engine.parse(sql) {
+            broadcast = stmts.iter().all(|s| {
+                matches!(
+                    s,
+                    Statement::CreateTable(_)
+                        | Statement::Drop {
+                            object_type: ObjectType::Table,
+                            ..
+                        }
+                )
+            });
+            is_write = stmts.iter().any(|s| {
+                matches!(
+                    s,
+                    Statement::Insert(_)
+                        | Statement::Update { .. }
+                        | Statement::Delete(_)
+                        | Statement::CreateTable(_)
+                        | Statement::Drop {
+                            object_type: ObjectType::Table,
+                            ..
+                        }
+                )
+            });
+        }
+
+        let ts = if is_write {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros() as u64
+        } else {
+            0
+        };
+
+        // Work out the target replica set.
+        let mut replicas: HashSet<String> = HashSet::new();
+        if broadcast {
+            replicas.extend(self.ring.values().cloned());
+        } else {
+            let keys = engine
+                .partition_keys(&self.db, sql)
+                .await
+                .unwrap_or_else(|_| vec![sql.to_string()]);
+            for key in keys {
+                for node in self.replicas_for(&key) {
+                    replicas.insert(node);
+                }
+            }
+            if replicas.is_empty() {
+                replicas.insert(self.self_addr.clone());
+            }
+        }
+
+        // Collect results from all replicas, performing last-write-wins per key.
+        let mut rows: BTreeMap<String, (u64, String)> = BTreeMap::new();
+        let mut others: BTreeSet<String> = BTreeSet::new();
+        let mut last_err: Option<QueryError> = None;
+        for node in replicas {
+            let payload = if ts > 0 {
+                format!("--ts:{}\n{}", ts, sql)
+            } else {
+                sql.to_string()
+            };
+            let resp = if node == self.self_addr {
+                engine.execute_with_ts(&self.db, sql, ts, true).await
+            } else {
+                let resp = self
+                    .client
+                    .post(format!("{}/internal", node))
+                    .body(payload)
+                    .send()
+                    .await;
+                match resp {
+                    Ok(resp) => {
+                        if resp.status().is_success() {
+                            match resp.bytes().await {
+                                Ok(bytes) => {
+                                    if bytes.is_empty() {
+                                        Ok(None)
+                                    } else {
+                                        Ok(Some(bytes.to_vec()))
+                                    }
+                                }
+                                Err(e) => Err(QueryError::Other(e.to_string())),
+                            }
+                        } else {
+                            Err(QueryError::Other(format!("status {}", resp.status())))
+                        }
+                    }
+                    Err(e) => Err(QueryError::Other(e.to_string())),
+                }
+            };
+
+            match resp {
+                Ok(Some(bytes)) => {
+                    let text = String::from_utf8_lossy(&bytes);
+                    for line in text.lines() {
+                        let parts: Vec<&str> = line.splitn(3, '\t').collect();
+                        if parts.len() == 3 {
+                            let key = parts[0].to_string();
+                            let ts: u64 = parts[1].parse().unwrap_or(0);
+                            let val = parts[2].to_string();
+                            match rows.get(&key) {
+                                Some((cur_ts, _)) if *cur_ts >= ts => {}
+                                _ => {
+                                    rows.insert(key, (ts, val));
+                                }
+                            }
+                        } else if !line.is_empty() {
+                            others.insert(line.to_string());
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => last_err = Some(e),
+            }
+        }
+
+        if !rows.is_empty() || !others.is_empty() {
+            let mut out: Vec<String> = Vec::new();
+            for (_k, (_ts, val)) in rows {
+                if !val.is_empty() {
+                    out.push(val);
+                }
+            }
+            out.extend(others.into_iter());
+            Ok(Some(out.join("\n").into_bytes()))
+        } else if let Some(err) = last_err {
+            Err(err)
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,11 @@ use std::{net::SocketAddr, sync::Arc};
 use axum::{Router, extract::State, http::StatusCode, routing::post};
 use clap::{Parser, ValueEnum};
 use lsmt::{
-    Database, SqlEngine,
+    Database,
+    cluster::Cluster,
     storage::{Storage, local::LocalStorage, s3::S3Storage},
 };
+use reqwest::Url;
 
 type DynStorage = Arc<dyn Storage>;
 
@@ -17,6 +19,14 @@ struct Args {
     data_dir: String,
     #[arg(long)]
     bucket: Option<String>,
+    #[arg(long, default_value = "http://127.0.0.1:8080")]
+    node_addr: String,
+    #[arg(long)]
+    peer: Vec<String>,
+    #[arg(long, default_value_t = 1)]
+    rf: usize,
+    #[arg(long, default_value_t = 8)]
+    vnodes: usize,
 }
 
 #[derive(Copy, Clone, ValueEnum)]
@@ -25,10 +35,23 @@ enum StorageKind {
     S3,
 }
 
-/// Handle incoming SQL queries sent to the server.
-async fn handle_query(State(db): State<Arc<Database>>, body: String) -> (StatusCode, String) {
-    let engine = SqlEngine::new();
-    match engine.execute(&db, &body).await {
+#[derive(Clone)]
+struct AppState {
+    cluster: Arc<Cluster>,
+}
+
+/// Handle incoming SQL queries sent by clients.
+async fn handle_query(State(state): State<AppState>, body: String) -> (StatusCode, String) {
+    match state.cluster.execute(&body, false).await {
+        Ok(Some(bytes)) => (StatusCode::OK, String::from_utf8_lossy(&bytes).to_string()),
+        Ok(None) => (StatusCode::OK, String::new()),
+        Err(e) => (StatusCode::BAD_REQUEST, e.to_string()),
+    }
+}
+
+/// Handle internal replication requests from peers.
+async fn handle_internal(State(state): State<AppState>, body: String) -> (StatusCode, String) {
+    match state.cluster.execute(&body, true).await {
         Ok(Some(bytes)) => (StatusCode::OK, String::from_utf8_lossy(&bytes).to_string()),
         Ok(None) => (StatusCode::OK, String::new()),
         Err(e) => (StatusCode::BAD_REQUEST, e.to_string()),
@@ -52,12 +75,23 @@ async fn main() {
         }
     };
     let db = Arc::new(Database::new(storage, "wal.log").await);
+    let cluster = Arc::new(Cluster::new(
+        db.clone(),
+        args.node_addr.clone(),
+        args.peer.clone(),
+        args.vnodes,
+        args.rf,
+    ));
+    let state = AppState { cluster };
 
     let app = Router::new()
         .route("/query", post(handle_query))
-        .with_state(db);
+        .route("/internal", post(handle_internal))
+        .with_state(state);
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
+    let url = Url::parse(&args.node_addr).expect("invalid --node-addr");
+    let port = url.port().unwrap_or(80);
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
     println!("LSMT server listening on {addr}");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();

--- a/tests/lsm_flush_test.rs
+++ b/tests/lsm_flush_test.rs
@@ -16,7 +16,9 @@ async fn flush_and_query_from_sstable() {
     db.flush().await.unwrap();
 
     // data should be retrievable even after memtable cleared
-    assert_eq!(db.get("k1").await, Some(b"v1".to_vec()));
-    assert_eq!(db.get("k2").await, Some(b"v2".to_vec()));
+    let v1 = db.get("k1").await.map(|b| b[8..].to_vec());
+    let v2 = db.get("k2").await.map(|b| b[8..].to_vec());
+    assert_eq!(v1, Some(b"v1".to_vec()));
+    assert_eq!(v2, Some(b"v2".to_vec()));
     assert_eq!(db.get("missing").await, None);
 }

--- a/tests/replication_http_test.rs
+++ b/tests/replication_http_test.rs
@@ -1,0 +1,120 @@
+use std::{
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+use reqwest::Client;
+
+#[tokio::test]
+async fn union_and_lww_across_replicas() {
+    let base1 = "http://127.0.0.1:18081";
+    let base2 = "http://127.0.0.1:18082";
+    let dir1 = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+    let bin = env!("CARGO_BIN_EXE_lsmt");
+
+    let mut child1 = Command::new(bin)
+        .args([
+            "--data-dir",
+            dir1.path().to_str().unwrap(),
+            "--node-addr",
+            base1,
+            "--peer",
+            base2,
+            "--rf",
+            "2",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut child2 = Command::new(bin)
+        .args([
+            "--data-dir",
+            dir2.path().to_str().unwrap(),
+            "--node-addr",
+            base2,
+            "--peer",
+            base1,
+            "--rf",
+            "2",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let client = Client::new();
+    for _ in 0..20 {
+        let ok1 = client
+            .post(format!("{}/query", base1))
+            .body("")
+            .send()
+            .await
+            .is_ok();
+        let ok2 = client
+            .post(format!("{}/query", base2))
+            .body("")
+            .send()
+            .await
+            .is_ok();
+        if ok1 && ok2 {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let create_sql = "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))";
+    client
+        .post(format!("{}/query", base1))
+        .body(create_sql)
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .post(format!("{}/internal", base1))
+        .body("--ts:1\nINSERT INTO kv (id, val) VALUES ('a','va1')")
+        .send()
+        .await
+        .unwrap();
+    client
+        .post(format!("{}/internal", base2))
+        .body("--ts:2\nINSERT INTO kv (id, val) VALUES ('a','va2')")
+        .send()
+        .await
+        .unwrap();
+    client
+        .post(format!("{}/internal", base2))
+        .body("--ts:3\nINSERT INTO kv (id, val) VALUES ('b','vb')")
+        .send()
+        .await
+        .unwrap();
+
+    let res_a = client
+        .post(format!("{}/query", base1))
+        .body("SELECT val FROM kv WHERE id = 'a'")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(res_a, "va2");
+
+    let res_b = client
+        .post(format!("{}/query", base1))
+        .body("SELECT val FROM kv WHERE id = 'b'")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(res_b, "vb");
+
+    child1.kill().unwrap();
+    child2.kill().unwrap();
+}

--- a/tests/wal_recovery_test.rs
+++ b/tests/wal_recovery_test.rs
@@ -16,5 +16,6 @@ async fn wal_recovery_after_restart() {
     }
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
     let db = Database::new(storage, wal).await;
-    assert_eq!(db.get("k1").await, Some(b"v1".to_vec()));
+    let v1 = db.get("k1").await.map(|b| b[8..].to_vec());
+    assert_eq!(v1, Some(b"v1".to_vec()));
 }


### PR DESCRIPTION
## Summary
- store microsecond timestamps with each mutation and expose timestamped insert APIs
- propagate timestamps through the cluster and merge replica responses using last-write-wins per row key
- add replication test verifying unioned results and LWW across replicas

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68a109551f4c832480afd2a3da5e5c33