### PR TITLE
Rename package and executable to cass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cass"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "clap",
+ "murmur3",
+ "reqwest 0.11.27",
+ "rust-s3",
+ "serde",
+ "serde_json",
+ "sqlparser",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,25 +1010,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lsmt"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.21.7",
- "clap",
- "murmur3",
- "reqwest 0.11.27",
- "rust-s3",
- "serde",
- "serde_json",
- "sqlparser",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "matchit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lsmt"
+name = "cass"
 version = "0.1.0"
 edition = "2024"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@
     # real sources
     COPY . .
     
-    # If your binary target is named `lsmt` (change if different):
+    # If your binary target is named `cass` (change if different):
     #   - add --bin <name> if your package defines multiple binaries or you're in a workspace
     RUN --mount=type=cache,target=/usr/local/cargo/registry \
         --mount=type=cache,target=/app/target \
-        cargo install --path . --bin lsmt --locked --root /out
+        cargo install --path . --bin cass --locked --root /out
     
     # ---- Runtime stage ----
     FROM debian:bookworm-slim
     # If needed: RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-    COPY --from=build /out/bin/lsmt /usr/local/bin/lsmt
-    CMD ["lsmt"]
+    COPY --from=build /out/bin/cass /usr/local/bin/cass
+    CMD ["cass"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '3.8'
 services:
-  lsmt1:
+  cass1:
     build: .
     volumes:
       - ./data1:/data
     command:
-      - "lsmt"
+      - "cass"
       - "--node-addr"
-      - "http://lsmt1:8080"
+      - "http://cass1:8080"
       - "--peer"
-      - "http://lsmt2:8080"
+      - "http://cass2:8080"
       - "--peer"
-      - "http://lsmt3:8080"
+      - "http://cass3:8080"
       - "--data-dir"
       - "/data"
       - "--rf"
@@ -19,18 +19,18 @@ services:
     ports:
       - "8080:8080"
 
-  lsmt2:
+  cass2:
     build: .
     volumes:
       - ./data2:/data
     command:
-      - "lsmt"
+      - "cass"
       - "--node-addr"
-      - "http://lsmt2:8080"
+      - "http://cass2:8080"
       - "--peer"
-      - "http://lsmt1:8080"
+      - "http://cass1:8080"
       - "--peer"
-      - "http://lsmt3:8080"
+      - "http://cass3:8080"
       - "--data-dir"
       - "/data"
       - "--rf"
@@ -38,18 +38,18 @@ services:
     ports:
       - "8081:8080"
 
-  lsmt3:
+  cass3:
     build: .
     volumes:
       - ./data3:/data
     command:
-      - "lsmt"
+      - "cass"
       - "--node-addr"
-      - "http://lsmt3:8080"
+      - "http://cass3:8080"
       - "--peer"
-      - "http://lsmt1:8080"
+      - "http://cass1:8080"
       - "--peer"
-      - "http://lsmt2:8080"
+      - "http://cass2:8080"
       - "--data-dir"
       - "/data"
       - "--rf"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use axum::{Router, extract::State, http::StatusCode, routing::post};
-use clap::{Parser, ValueEnum};
-use lsmt::{
+use cass::{
     Database,
     cluster::Cluster,
     storage::{Storage, local::LocalStorage, s3::S3Storage},
 };
+use clap::{Parser, ValueEnum};
 use reqwest::Url;
 
 type DynStorage = Arc<dyn Storage>;
@@ -15,7 +15,7 @@ type DynStorage = Arc<dyn Storage>;
 struct Args {
     #[arg(long, default_value = "local", value_enum)]
     storage: StorageKind,
-    #[arg(long, default_value = "/tmp/lsmt-data")]
+    #[arg(long, default_value = "/tmp/cass-data")]
     data_dir: String,
     #[arg(long)]
     bucket: Option<String>,
@@ -92,7 +92,7 @@ async fn main() {
     let url = Url::parse(&args.node_addr).expect("invalid --node-addr");
     let port = url.port().unwrap_or(80);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    println!("LSMT server listening on {addr}");
+    println!("Cass server listening on {addr}");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
 }

--- a/tests/bloom_test.rs
+++ b/tests/bloom_test.rs
@@ -1,4 +1,4 @@
-use lsmt::bloom::BloomFilter;
+use cass::bloom::BloomFilter;
 
 #[test]
 fn bloom_insert_check() {

--- a/tests/e2e_local.rs
+++ b/tests/e2e_local.rs
@@ -1,4 +1,4 @@
-use lsmt::{
+use cass::{
     Database, SqlEngine,
     storage::{Storage, local::LocalStorage},
 };

--- a/tests/lsm_flush_test.rs
+++ b/tests/lsm_flush_test.rs
@@ -1,4 +1,4 @@
-use lsmt::{
+use cass::{
     Database,
     storage::{Storage, local::LocalStorage},
 };

--- a/tests/query_advanced_test.rs
+++ b/tests/query_advanced_test.rs
@@ -1,5 +1,5 @@
-use lsmt::storage::{Storage, local::LocalStorage};
-use lsmt::{Database, SqlEngine};
+use cass::storage::{Storage, local::LocalStorage};
+use cass::{Database, SqlEngine};
 use std::sync::Arc;
 
 #[tokio::test]

--- a/tests/query_http_test.rs
+++ b/tests/query_http_test.rs
@@ -6,9 +6,9 @@ use std::{
 
 #[tokio::test]
 async fn http_query_roundtrip() {
-    let _ = std::fs::remove_dir_all("/tmp/lsmt-data");
+    let _ = std::fs::remove_dir_all("/tmp/cass-data");
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_lsmt"))
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cass"))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/tests/query_schema_test.rs
+++ b/tests/query_schema_test.rs
@@ -1,5 +1,5 @@
-use lsmt::storage::{Storage, local::LocalStorage};
-use lsmt::{Database, SqlEngine};
+use cass::storage::{Storage, local::LocalStorage};
+use cass::{Database, SqlEngine};
 use std::sync::Arc;
 
 #[tokio::test]

--- a/tests/replication_http_test.rs
+++ b/tests/replication_http_test.rs
@@ -12,7 +12,7 @@ async fn union_and_lww_across_replicas() {
     let base2 = "http://127.0.0.1:18082";
     let dir1 = tempfile::tempdir().unwrap();
     let dir2 = tempfile::tempdir().unwrap();
-    let bin = env!("CARGO_BIN_EXE_lsmt");
+    let bin = env!("CARGO_BIN_EXE_cass");
 
     let mut child1 = Command::new(bin)
         .args([

--- a/tests/sstable_local_test.rs
+++ b/tests/sstable_local_test.rs
@@ -1,11 +1,13 @@
-use lsmt::{sstable::SsTable, storage::local::LocalStorage};
+use cass::{sstable::SsTable, storage::local::LocalStorage};
 
 #[tokio::test]
 async fn sstable_local_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let storage = LocalStorage::new(dir.path());
     let entries = vec![("k".to_string(), b"v".to_vec())];
-    let table = SsTable::create("data.tbl", &entries, &storage).await.unwrap();
+    let table = SsTable::create("data.tbl", &entries, &storage)
+        .await
+        .unwrap();
     let res = table.get("k", &storage).await.unwrap();
     assert_eq!(res, Some(b"v".to_vec()));
 }

--- a/tests/sstable_test.rs
+++ b/tests/sstable_test.rs
@@ -1,4 +1,4 @@
-use lsmt::{sstable::SsTable, storage::local::LocalStorage};
+use cass::{sstable::SsTable, storage::local::LocalStorage};
 
 #[tokio::test]
 async fn sstable_roundtrip() {

--- a/tests/wal_recovery_test.rs
+++ b/tests/wal_recovery_test.rs
@@ -1,4 +1,4 @@
-use lsmt::{
+use cass::{
     Database,
     storage::{Storage, local::LocalStorage},
 };


### PR DESCRIPTION
## Summary
- rename `lsmt` crate and binary to `cass`
- update tests, Dockerfile, and docker-compose to use new name
- set default data directory to `/tmp/cass-data`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a17e5cd9908324ae567d35d6761a02