### PR TITLE
Sort SSTable keys and use binary search

### DIFF
--- a/tests/sstable_test.rs
+++ b/tests/sstable_test.rs
@@ -1,4 +1,7 @@
-use cass::{sstable::SsTable, storage::local::LocalStorage};
+use cass::{
+    sstable::SsTable,
+    storage::{Storage, local::LocalStorage},
+};
 
 #[tokio::test]
 async fn sstable_roundtrip() {

--- a/tests/sstable_test.rs
+++ b/tests/sstable_test.rs
@@ -1,14 +1,25 @@
-use lsmt::{sstable::SsTable, storage::local::LocalStorage};
+use lsmt::{
+    sstable::SsTable,
+    storage::{Storage, local::LocalStorage},
+};
 
 #[tokio::test]
 async fn sstable_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let storage = LocalStorage::new(dir.path());
     let entries = vec![
-        ("a".to_string(), b"1".to_vec()),
         ("b".to_string(), b"2".to_vec()),
+        ("a".to_string(), b"1".to_vec()),
+        ("c".to_string(), b"3".to_vec()),
     ];
     let table = SsTable::create("table", &entries, &storage).await.unwrap();
     assert_eq!(table.get("a", &storage).await.unwrap(), Some(b"1".to_vec()));
-    assert_eq!(table.get("c", &storage).await.unwrap(), None);
+    assert_eq!(table.get("b", &storage).await.unwrap(), Some(b"2".to_vec()));
+    let raw = storage.get("table").await.unwrap();
+    let text = String::from_utf8(raw).unwrap();
+    let keys: Vec<&str> = text
+        .lines()
+        .map(|l| l.split('\t').next().unwrap())
+        .collect();
+    assert_eq!(keys, vec!["a", "b", "c"]);
 }


### PR DESCRIPTION
## Summary
- Ensure SSTable entries are sorted by key before being written
- Perform binary search over SSTable keys for faster lookups
- Factor binary search logic into a helper with thorough documentation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a17f31f0508324b4eb08be99ebd844