### PR TITLE
Improve resilience and replication performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "clap",
+ "futures",
  "murmur3",
  "reqwest 0.11.27",
  "rust-s3",
@@ -476,6 +477,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -497,6 +499,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -533,6 +546,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 murmur3 = "0.5"
+futures = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ cargo test            # run unit tests
 cargo run             # start the HTTP query service on port 8080
 ```
 
+### Contributing
+
+Before submitting changes, ensure the code is formatted and tests pass:
+
+```bash
+cargo fmt
+cargo test
+```
+
+The project uses idiomatic Rust patterns with small, focused functions. See the
+module-level comments in `src/` for a high-level overview of the architecture.
+
 ## Storage Backends
 
 The server supports both local filesystem storage and Amazon S3.

--- a/src/query.rs
+++ b/src/query.rs
@@ -22,7 +22,7 @@ fn split_ts(bytes: &[u8]) -> (u64, &[u8]) {
     if bytes.len() < 8 {
         return (0, bytes);
     }
-    let ts = u64::from_be_bytes(bytes[..8].try_into().unwrap());
+    let ts = u64::from_be_bytes(bytes[..8].try_into().unwrap_or([0; 8]));
     (ts, &bytes[8..])
 }
 
@@ -62,7 +62,7 @@ impl SqlEngine {
     pub async fn execute(&self, db: &Database, sql: &str) -> Result<Option<Vec<u8>>, QueryError> {
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_else(|_| std::time::Duration::from_secs(0))
             .as_micros() as u64;
         self.execute_with_ts(db, sql, ts, false).await
     }
@@ -96,7 +96,9 @@ impl SqlEngine {
             Statement::Insert(insert) => {
                 let count = self.exec_insert(db, insert, ts).await?;
                 let out = json!({"op":"INSERT","unit":"row","count":count});
-                Ok(Some(serde_json::to_vec(&out).unwrap()))
+                let bytes =
+                    serde_json::to_vec(&out).map_err(|e| QueryError::Other(e.to_string()))?;
+                Ok(Some(bytes))
             }
             Statement::Update {
                 table,
@@ -108,12 +110,16 @@ impl SqlEngine {
                     .exec_update(db, table, assignments, selection, ts)
                     .await?;
                 let out = json!({"op":"UPDATE","unit":"row","count":count});
-                Ok(Some(serde_json::to_vec(&out).unwrap()))
+                let bytes =
+                    serde_json::to_vec(&out).map_err(|e| QueryError::Other(e.to_string()))?;
+                Ok(Some(bytes))
             }
             Statement::Delete(delete) => {
                 let count = self.exec_delete(db, delete, ts).await?;
                 let out = json!({"op":"DELETE","unit":"row","count":count});
-                Ok(Some(serde_json::to_vec(&out).unwrap()))
+                let bytes =
+                    serde_json::to_vec(&out).map_err(|e| QueryError::Other(e.to_string()))?;
+                Ok(Some(bytes))
             }
             Statement::CreateTable(ct) => {
                 let ns = object_name_to_ns(&ct.name).ok_or(QueryError::Unsupported)?;
@@ -124,7 +130,9 @@ impl SqlEngine {
                 save_schema(db, &ns, &schema).await;
                 register_table(db, &ns).await;
                 let out = json!({"op":"CREATE TABLE","unit":"table","count":1});
-                Ok(Some(serde_json::to_vec(&out).unwrap()))
+                let bytes =
+                    serde_json::to_vec(&out).map_err(|e| QueryError::Other(e.to_string()))?;
+                Ok(Some(bytes))
             }
             Statement::ShowTables { .. } => self.exec_show_tables(db).await,
             Statement::Drop {
@@ -138,7 +146,9 @@ impl SqlEngine {
                     db.delete_ns("_tables", &ns).await;
                     db.delete_ns("_schemas", &ns).await;
                     let out = json!({"op":"DROP TABLE","unit":"table","count":1});
-                    Ok(Some(serde_json::to_vec(&out).unwrap()))
+                    let bytes =
+                        serde_json::to_vec(&out).map_err(|e| QueryError::Other(e.to_string()))?;
+                    Ok(Some(bytes))
                 } else {
                     Err(QueryError::Unsupported)
                 }
@@ -347,8 +357,13 @@ impl SqlEngine {
         if key_cols.iter().all(|c| cond_map.contains_key(c)) {
             let key_parts: Vec<String> = key_cols
                 .iter()
-                .map(|c| cond_map.get(c).cloned().unwrap())
-                .collect();
+                .map(|c| {
+                    cond_map
+                        .get(c)
+                        .cloned()
+                        .ok_or_else(|| QueryError::Other("missing key".to_string()))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             let key = key_parts.join("|");
             if let Some(bytes) = db.get_ns(ns, &key).await {
                 let (_, data) = split_ts(&bytes);
@@ -387,7 +402,8 @@ impl SqlEngine {
             }
         }
         let out = json!([{ "count": count }]);
-        Ok(Some(serde_json::to_vec(&out).unwrap()))
+        let bytes = serde_json::to_vec(&out).map_err(|e| QueryError::Other(e.to_string()))?;
+        Ok(Some(bytes))
     }
 
     /// Simplified `SELECT` handler for schema-aware tables.
@@ -486,7 +502,9 @@ impl SqlEngine {
                 Ok(Some(meta_lines.join("\n").into_bytes()))
             }
         } else {
-            Ok(Some(serde_json::to_vec(&out_rows).unwrap()))
+            let bytes =
+                serde_json::to_vec(&out_rows).map_err(|e| QueryError::Other(e.to_string()))?;
+            Ok(Some(bytes))
         }
     }
 
@@ -499,7 +517,8 @@ impl SqlEngine {
             .map(|(k, _)| k)
             .collect();
         tables.sort();
-        Ok(Some(serde_json::to_vec(&tables).unwrap()))
+        let bytes = serde_json::to_vec(&tables).map_err(|e| QueryError::Other(e.to_string()))?;
+        Ok(Some(bytes))
     }
 
     /// Extract partition key values from `sql` for routing and replication.
@@ -613,8 +632,9 @@ async fn get_schema(db: &Database, table: &str) -> Option<TableSchema> {
 
 /// Persist a schema definition for a table.
 async fn save_schema(db: &Database, table: &str, schema: &TableSchema) {
-    let data = serde_json::to_vec(schema).unwrap_or_default();
-    db.insert_ns("_schemas", table.to_string(), data).await;
+    if let Ok(data) = serde_json::to_vec(schema) {
+        db.insert_ns("_schemas", table.to_string(), data).await;
+    }
 }
 
 /// Build a [`TableSchema`] from a parsed `CREATE TABLE` statement.

--- a/tests/e2e_local.rs
+++ b/tests/e2e_local.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 async fn e2e_insert_select() {
     let dir = tempfile::tempdir().unwrap();
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
-    let db = Database::new(storage, "wal.log").await;
+    let db = Database::new(storage, "wal.log").await.unwrap();
     let engine = SqlEngine::new();
     engine
         .execute(&db, "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))")

--- a/tests/lsm_flush_test.rs
+++ b/tests/lsm_flush_test.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 async fn flush_and_query_from_sstable() {
     let dir = tempfile::tempdir().unwrap();
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
-    let db = Database::new(storage, "wal.log").await;
+    let db = Database::new(storage, "wal.log").await.unwrap();
 
     db.insert("k1".to_string(), b"v1".to_vec()).await;
     db.insert("k2".to_string(), b"v2".to_vec()).await;

--- a/tests/query_advanced_test.rs
+++ b/tests/query_advanced_test.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 async fn update_delete_and_count() {
     let tmp = tempfile::tempdir().unwrap();
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(tmp.path()));
-    let db = Database::new(storage, "wal.log").await;
+    let db = Database::new(storage, "wal.log").await.unwrap();
     let engine = SqlEngine::new();
 
     engine
@@ -79,7 +79,7 @@ async fn update_delete_and_count() {
 async fn table_names_and_cast() {
     let tmp = tempfile::tempdir().unwrap();
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(tmp.path()));
-    let db = Database::new(storage, "wal.log").await;
+    let db = Database::new(storage, "wal.log").await.unwrap();
     let engine = SqlEngine::new();
 
     engine
@@ -108,7 +108,7 @@ async fn table_names_and_cast() {
 async fn multi_row_insert_count() {
     let tmp = tempfile::tempdir().unwrap();
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(tmp.path()));
-    let db = Database::new(storage, "wal.log").await;
+    let db = Database::new(storage, "wal.log").await.unwrap();
     let engine = SqlEngine::new();
 
     engine

--- a/tests/query_schema_test.rs
+++ b/tests/query_schema_test.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 async fn create_insert_select_schema_table() {
     let tmp = tempfile::tempdir().unwrap();
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(tmp.path()));
-    let db = Database::new(storage, "wal.log").await;
+    let db = Database::new(storage, "wal.log").await.unwrap();
     let engine = SqlEngine::new();
 
     engine
@@ -39,7 +39,7 @@ async fn create_insert_select_schema_table() {
 async fn create_existing_table_fails() {
     let tmp = tempfile::tempdir().unwrap();
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(tmp.path()));
-    let db = Database::new(storage, "wal.log").await;
+    let db = Database::new(storage, "wal.log").await.unwrap();
     let engine = SqlEngine::new();
 
     engine

--- a/tests/wal_error_test.rs
+++ b/tests/wal_error_test.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cass::{
+    Database,
+    storage::{Storage, StorageError},
+};
+
+struct BadStorage;
+
+#[async_trait]
+impl Storage for BadStorage {
+    async fn put(&self, _path: &str, _data: Vec<u8>) -> Result<(), StorageError> {
+        Ok(())
+    }
+
+    async fn get(&self, _path: &str) -> Result<Vec<u8>, StorageError> {
+        // return invalid WAL data to trigger a parse error
+        Ok(b"bad\t@@\n".to_vec())
+    }
+}
+
+#[tokio::test]
+async fn database_new_propagates_wal_error() {
+    let storage: Arc<dyn Storage> = Arc::new(BadStorage);
+    let res = Database::new(storage, "wal.log").await;
+    assert!(res.is_err());
+}

--- a/tests/wal_recovery_test.rs
+++ b/tests/wal_recovery_test.rs
@@ -11,11 +11,11 @@ async fn wal_recovery_after_restart() {
     let wal = "wal.log";
     {
         let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
-        let db = Database::new(storage, wal).await;
+        let db = Database::new(storage, wal).await.unwrap();
         db.insert("k1".to_string(), b"v1".to_vec()).await;
     }
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
-    let db = Database::new(storage, wal).await;
+    let db = Database::new(storage, wal).await.unwrap();
     let v1 = db.get("k1").await.map(|b| b[8..].to_vec());
     assert_eq!(v1, Some(b"v1".to_vec()));
 }


### PR DESCRIPTION
## Summary
- propagate WAL initialization errors and avoid timestamp panics
- execute replication requests in parallel and remove `unwrap`
- document contribution workflow and add WAL error regression test

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a187042a848324bdf6221cf3453408