### PR TITLE
Add coverage reporting to CI and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Generate coverage report
+        run: cargo tarpaulin --out Xml
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3
+        with:
+          files: cobertura.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Cass
+[![codecov](https://codecov.io/gh/OWNER/cass/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/cass)
 
 Toy/experimental clone of [Apache Cassandra](https://en.wikipedia.org/wiki/Apache_Cassandra) written in Rust. Written mostly via [OpenAI Codex](https://chatgpt.com/codex).
 


### PR DESCRIPTION
## Summary
- collect coverage with cargo-tarpaulin and upload via codecov in CI
- show coverage badge at top of README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a2634804e883249898efe257bb2984