### PR TITLE
Add unit tests for memtable, storage and query utilities

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -825,3 +825,78 @@ fn cast_simple(val: &str, data_type: &DataType) -> Option<String> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use sqlparser::ast::{DataType, Expr, Ident, ObjectName, ObjectNamePart, TableFactor, Value};
+
+    #[test]
+    fn split_ts_handles_short_buffers() {
+        let buf = [1u8, 2u8, 3u8];
+        let (ts, rest) = super::split_ts(&buf);
+        assert_eq!(ts, 0);
+        assert_eq!(rest, &buf);
+    }
+
+    #[test]
+    fn split_ts_parses_timestamp_and_rest() {
+        let ts_val: u64 = 42;
+        let mut buf = ts_val.to_be_bytes().to_vec();
+        buf.extend_from_slice(b"hello");
+        let (ts, rest) = super::split_ts(&buf);
+        assert_eq!(ts, ts_val);
+        assert_eq!(rest, b"hello");
+    }
+
+    #[test]
+    fn object_name_to_ns_extracts_last_segment_lowercase() {
+        let name = ObjectName(vec![
+            ObjectNamePart::Identifier(Ident::new("Foo")),
+            ObjectNamePart::Identifier(Ident::new("Bar")),
+        ]);
+        assert_eq!(super::object_name_to_ns(&name), Some("bar".to_string()));
+    }
+
+    #[test]
+    fn object_name_to_ns_returns_none_for_empty() {
+        let name = ObjectName(vec![]);
+        assert!(super::object_name_to_ns(&name).is_none());
+    }
+
+    #[test]
+    fn table_factor_to_ns_handles_table_and_non_table() {
+        let table = TableFactor::Table {
+            name: ObjectName(vec![ObjectNamePart::Identifier(Ident::new("users"))]),
+            alias: None,
+            args: None,
+            with_hints: vec![],
+            version: None,
+            with_ordinality: false,
+            partitions: vec![],
+            json_path: None,
+            sample: None,
+            index_hints: vec![],
+        };
+        assert_eq!(super::table_factor_to_ns(&table), Some("users".to_string()));
+
+        let func = TableFactor::TableFunction {
+            expr: Expr::Value(Value::Number("1".into(), false).into()),
+            alias: None,
+        };
+        assert!(super::table_factor_to_ns(&func).is_none());
+    }
+
+    #[test]
+    fn cast_simple_covers_types_and_errors() {
+        assert_eq!(
+            super::cast_simple("123", &DataType::Int(None)),
+            Some("123".to_string())
+        );
+        assert!(super::cast_simple("abc", &DataType::Int(None)).is_none());
+        assert_eq!(
+            super::cast_simple("hi", &DataType::Text),
+            Some("hi".to_string())
+        );
+        assert!(super::cast_simple("t", &DataType::Boolean).is_none());
+    }
+}

--- a/tests/memtable_test.rs
+++ b/tests/memtable_test.rs
@@ -1,0 +1,52 @@
+use cass::memtable::MemTable;
+
+#[tokio::test]
+async fn memtable_basic_operations() {
+    let table = MemTable::new();
+
+    // insert and get
+    table.insert("k1".to_string(), b"v1".to_vec()).await;
+    assert_eq!(table.len().await, 1);
+    assert_eq!(table.get("k1").await, Some(b"v1".to_vec()));
+
+    // get missing
+    assert!(table.get("missing").await.is_none());
+
+    // delete existing and missing
+    table.delete("k1").await;
+    table.delete("missing").await; // should be no-op
+    assert_eq!(table.len().await, 0);
+}
+
+#[tokio::test]
+async fn memtable_scan_clear_and_prefix() {
+    let table = MemTable::new();
+    table.insert("a1".to_string(), b"v1".to_vec()).await;
+    table.insert("a2".to_string(), b"v2".to_vec()).await;
+    table.insert("b1".to_string(), b"v3".to_vec()).await;
+
+    // scan returns sorted pairs
+    let scan = table.scan().await;
+    assert_eq!(
+        scan,
+        vec![
+            ("a1".to_string(), b"v1".to_vec()),
+            ("a2".to_string(), b"v2".to_vec()),
+            ("b1".to_string(), b"v3".to_vec()),
+        ]
+    );
+
+    // delete prefix affects matching keys
+    table.delete_prefix("a").await;
+    assert_eq!(table.len().await, 1);
+    assert!(table.get("a1").await.is_none());
+    assert!(table.get("b1").await.is_some());
+
+    // deleting with empty prefix clears all
+    table.delete_prefix("").await;
+    assert_eq!(table.len().await, 0);
+
+    table.insert("x".to_string(), b"y".to_vec()).await;
+    table.clear().await;
+    assert_eq!(table.len().await, 0);
+}

--- a/tests/storage_local_test.rs
+++ b/tests/storage_local_test.rs
@@ -1,0 +1,23 @@
+use cass::storage::Storage;
+use cass::storage::local::LocalStorage;
+
+#[tokio::test]
+async fn local_storage_put_and_get() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(tmp.path());
+
+    storage
+        .put("nested/dir/file.txt", b"hello".to_vec())
+        .await
+        .unwrap();
+    let data = storage.get("nested/dir/file.txt").await.unwrap();
+    assert_eq!(data, b"hello");
+}
+
+#[tokio::test]
+async fn local_storage_get_missing_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(tmp.path());
+    let res = storage.get("missing").await;
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## Summary
- add tests for MemTable covering insert, scan, delete and prefix removal paths
- test LocalStorage put/get behavior and missing file errors
- add unit tests for query helpers like timestamp splitting and namespace extraction

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a2706774648324872de588ec5d6e5d