### PR TITLE
Add unit tests for cluster operations

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -95,7 +95,7 @@ impl Cluster {
         }
     }
 
-    fn replicas_for(&self, key: &str) -> Vec<String> {
+    pub fn replicas_for(&self, key: &str) -> Vec<String> {
         let mut cursor = Cursor::new(key.as_bytes());
         let token = murmur3_32(&mut cursor, 0).unwrap_or(0);
         let mut reps = Vec::new();
@@ -118,7 +118,7 @@ impl Cluster {
         reps
     }
 
-    async fn is_alive(&self, node: &str) -> bool {
+    pub async fn is_alive(&self, node: &str) -> bool {
         if node == self.self_addr {
             return true;
         }

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -1,0 +1,48 @@
+use cass::Database;
+use cass::cluster::Cluster;
+use cass::storage::local::LocalStorage;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+
+async fn build_cluster(peers: Vec<String>, vnodes: usize, rf: usize, self_addr: &str) -> Cluster {
+    let dir = tempdir().unwrap();
+    let storage = Arc::new(LocalStorage::new(dir.path()));
+    let db = Arc::new(Database::new(storage, "wal.log").await.unwrap());
+    Cluster::new(db, self_addr.to_string(), peers, vnodes, rf)
+}
+
+#[tokio::test]
+async fn replicas_for_returns_unique_nodes() {
+    let self_addr = "http://127.0.0.1:1000".to_string();
+    let peer = "http://127.0.0.1:1001".to_string();
+    let cluster = build_cluster(vec![peer.clone()], 2, 2, &self_addr).await;
+    let reps = cluster.replicas_for("somekey");
+    assert_eq!(reps.len(), 2);
+    let set: HashSet<_> = reps.iter().cloned().collect();
+    assert_eq!(set.len(), 2);
+    assert!(set.contains(&self_addr));
+    assert!(set.contains(&peer));
+}
+
+#[tokio::test]
+async fn is_alive_false_when_stale() {
+    let self_addr = "http://127.0.0.1:2000".to_string();
+    let peer = "http://127.0.0.1:2001".to_string();
+    let cluster = build_cluster(vec![peer.clone()], 1, 1, &self_addr).await;
+    assert!(cluster.is_alive(&self_addr).await);
+    assert!(cluster.is_alive(&peer).await);
+    tokio::time::sleep(Duration::from_secs(9)).await;
+    assert!(!cluster.is_alive(&peer).await);
+}
+
+#[tokio::test]
+async fn health_info_reports_tokens() {
+    let self_addr = "http://127.0.0.1:3000".to_string();
+    let cluster = build_cluster(Vec::new(), 3, 1, &self_addr).await;
+    let info = cluster.health_info();
+    assert_eq!(info["node"].as_str().unwrap(), self_addr);
+    assert_eq!(info["tokens"].as_array().unwrap().len(), 3);
+    assert!(info["timestamp"].as_u64().is_some());
+}


### PR DESCRIPTION
## Summary
- expose replica selection and liveness helpers for testing
- move cluster checks into integration tests for duplicates, liveness expiry, and token reporting

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a2778079208324aa7664a673c06af3