### PR TITLE
Add Prometheus metrics and Grafana monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "futures",
  "hyper-util",
  "murmur3",
+ "prometheus",
  "reqwest 0.11.27",
  "rust-s3",
  "s3s",
@@ -323,6 +324,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlparser",
+ "sysinfo",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -509,6 +511,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +612,12 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -1052,7 +1085,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1255,6 +1288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nugine-rust-utils"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1471,29 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "path-absolutize"
@@ -1488,6 +1563,27 @@ checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psm"
@@ -1628,6 +1724,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "recursive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +1761,15 @@ checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1979,6 +2104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2351,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -2777,6 +2923,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 murmur3 = "0.5"
 futures = "0.3"
 chrono = "0.4"
+prometheus = "0.13"
+sysinfo = "0.30"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -116,3 +116,17 @@ curl -X POST localhost:8082/query -d "SELECT value FROM id WHERE key = 'hello'"
 curl -X POST localhost:8083/query -d "SELECT value FROM id WHERE key = 'hello'"
 curl -X POST localhost:8084/query -d "SELECT value FROM id WHERE key = 'hello'"
 ```
+
+## Monitoring
+
+Each node exposes Prometheus metrics at `/metrics`. The provided
+`docker-compose.yml` also starts Prometheus and Grafana. After running
+
+```bash
+docker compose up
+```
+
+visit <http://localhost:3000> and sign in with the default
+`admin`/`admin` credentials. The Grafana instance is preconfigured with the
+Prometheus data source so you can explore metrics such as HTTP request
+counts, peer health, RAM and CPU usage, and SSTable disk usage.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,3 +115,22 @@ services:
     ports:
       - "8084:8080"
 
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - '9090:9090'
+
+  grafana:
+    image: grafana/grafana:latest
+    depends_on:
+      - prometheus
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana/provisioning/datasources/prometheus.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+    ports:
+      - '3000:3000'

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'cass'
+    static_configs:
+      - targets:
+          - cass1:8080
+          - cass2:8080
+          - cass3:8080
+          - cass4:8080
+          - cass5:8080

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -128,6 +128,13 @@ impl Cluster {
             .unwrap_or(false)
     }
 
+    pub async fn peer_health(&self) -> Vec<(String, bool)> {
+        let map = self.health.read().await;
+        map.iter()
+            .map(|(peer, t)| (peer.clone(), t.elapsed() < Duration::from_secs(8)))
+            .collect()
+    }
+
     pub fn health_info(&self) -> Value {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{fs, net::SocketAddr, path::Path, sync::Arc, time::Instant};
 
 use axum::{
     Json, Router,
@@ -6,7 +6,7 @@ use axum::{
     extract::{ConnectInfo, State},
     http::{Request, StatusCode, Version},
     middleware::{self, Next},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use cass::{
@@ -16,8 +16,13 @@ use cass::{
 };
 use chrono::Utc;
 use clap::{Parser, ValueEnum};
+use prometheus::{
+    Encoder, Gauge, HistogramVec, IntCounterVec, IntGaugeVec, TextEncoder, register_gauge,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec,
+};
 use reqwest::Url;
 use serde_json::Value;
+use sysinfo::System;
 
 type DynStorage = Arc<dyn Storage>;
 
@@ -48,6 +53,47 @@ enum StorageKind {
 #[derive(Clone)]
 struct AppState {
     cluster: Arc<Cluster>,
+    metrics: Arc<Metrics>,
+    data_dir: String,
+}
+
+#[derive(Clone)]
+struct Metrics {
+    req_count: IntCounterVec,
+    req_duration: HistogramVec,
+    health: IntGaugeVec,
+    ram: Gauge,
+    cpu: Gauge,
+    sstable: Gauge,
+}
+
+impl Metrics {
+    fn new() -> Self {
+        Self {
+            req_count: register_int_counter_vec!(
+                "http_requests_total",
+                "HTTP request counts",
+                &["method", "path", "status"]
+            )
+            .unwrap(),
+            req_duration: register_histogram_vec!(
+                "http_request_duration_seconds",
+                "HTTP request latencies",
+                &["method", "path", "status"]
+            )
+            .unwrap(),
+            health: register_int_gauge_vec!(
+                "node_health",
+                "Health status of peer nodes",
+                &["peer"]
+            )
+            .unwrap(),
+            ram: register_gauge!("ram_usage_bytes", "RAM usage in bytes").unwrap(),
+            cpu: register_gauge!("cpu_usage_percent", "CPU usage percentage").unwrap(),
+            sstable: register_gauge!("sstable_disk_usage_bytes", "SSTable disk usage in bytes")
+                .unwrap(),
+        }
+    }
 }
 
 /// Handle incoming SQL queries sent by clients.
@@ -93,14 +139,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.vnodes,
         args.rf,
     ));
-    let state = AppState { cluster };
+    let metrics = Arc::new(Metrics::new());
+    let state = AppState {
+        cluster,
+        metrics: metrics.clone(),
+        data_dir: args.data_dir.clone(),
+    };
 
     let app = Router::new()
         .route("/query", post(handle_query))
         .route("/internal", post(handle_internal))
         .route("/health", get(handle_health))
-        .with_state(state)
-        .layer(middleware::from_fn(common_log));
+        .route("/metrics", get(handle_metrics))
+        .with_state(state.clone())
+        .layer(middleware::from_fn_with_state(state, common_log));
 
     let url = Url::parse(&args.node_addr)?;
     let port = url.port().unwrap_or(80);
@@ -118,7 +170,58 @@ async fn handle_health(State(state): State<AppState>) -> Json<Value> {
     Json(state.cluster.health_info())
 }
 
+async fn handle_metrics(State(state): State<AppState>) -> impl IntoResponse {
+    for (peer, alive) in state.cluster.peer_health().await {
+        state
+            .metrics
+            .health
+            .with_label_values(&[&peer])
+            .set(if alive { 1 } else { 0 });
+    }
+
+    let mut sys = System::new_all();
+    sys.refresh_memory();
+    sys.refresh_cpu();
+    let ram = sys.used_memory() as f64 * 1024.0;
+    let cpu = sys.global_cpu_info().cpu_usage() as f64;
+    state.metrics.ram.set(ram);
+    state.metrics.cpu.set(cpu);
+    let disk = sstable_disk_usage(&state.data_dir) as f64;
+    state.metrics.sstable.set(disk);
+
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    let mut buffer = Vec::new();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, encoder.format_type())
+        .body(String::from_utf8(buffer).unwrap())
+        .unwrap()
+}
+
+fn sstable_disk_usage(dir: &str) -> u64 {
+    fn visit(path: &Path) -> u64 {
+        let mut size = 0;
+        if let Ok(entries) = fs::read_dir(path) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    size += visit(&p);
+                } else if p.extension().and_then(|e| e.to_str()) == Some("sst") {
+                    if let Ok(meta) = entry.metadata() {
+                        size += meta.len();
+                    }
+                }
+            }
+        }
+        size
+    }
+    visit(Path::new(dir))
+}
+
 async fn common_log(
+    State(state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     req: Request<Body>,
     next: Next,
@@ -132,6 +235,7 @@ async fn common_log(
         Version::HTTP_3 => "HTTP/3.0",
         _ => "HTTP/?",
     };
+    let start = Instant::now();
     let response = next.run(req).await;
     let status = response.status().as_u16();
     let length = response
@@ -150,5 +254,18 @@ async fn common_log(
         status,
         length
     );
+    let status_str = status.to_string();
+    let path = uri.path().to_string();
+    let elapsed = start.elapsed().as_secs_f64();
+    state
+        .metrics
+        .req_count
+        .with_label_values(&[method.as_str(), path.as_str(), &status_str])
+        .inc();
+    state
+        .metrics
+        .req_duration
+        .with_label_values(&[method.as_str(), path.as_str(), &status_str])
+        .observe(elapsed);
     response
 }


### PR DESCRIPTION
## Summary
- expose Prometheus metrics for HTTP traffic, peer health, and resource usage
- add Prometheus and Grafana services to docker-compose with configs
- document how to view metrics in Grafana

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a90e5c8c832485d6b8b6725a8459