### PR TITLE
Mount Grafana dashboard via docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,5 +132,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
       - ./grafana/provisioning/datasources/prometheus.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+      - ./grafana/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./static/dashboard.json:/var/lib/grafana/dashboards/dashboard.json:ro
     ports:
       - '3000:3000'

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: 'cass-dashboard'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards


### PR DESCRIPTION
## Summary
- provision Grafana to load dashboard JSON
- mount static dashboard config in docker-compose

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a2cc9cc2088324912df0ad673a6c3c