### PR TITLE
Load existing SSTables on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +323,7 @@ dependencies = [
  "hyper-util",
  "murmur3",
  "prometheus",
+ "prost",
  "reqwest 0.11.27",
  "rust-s3",
  "s3s",
@@ -1248,6 +1255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1593,29 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3"
 chrono = "0.4"
 prometheus = "0.13"
 sysinfo = "0.30"
+prost = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -1,14 +1,23 @@
 /// Simple bloom filter implementation used to provide probabilistic
 /// membership tests for on-disk SSTables.
+use prost::Message;
 pub struct BloomFilter {
     /// Bit vector storing hashed membership information.
     bits: Vec<bool>,
 }
 
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BloomProto {
+    #[prost(bool, repeated, tag = "1")]
+    pub bits: Vec<bool>,
+}
+
 impl BloomFilter {
     /// Create a new filter with `size` bits.
     pub fn new(size: usize) -> Self {
-        Self { bits: vec![false; size] }
+        Self {
+            bits: vec![false; size],
+        }
     }
 
     /// Compute two simple hash values for `item` using a pair of
@@ -38,7 +47,32 @@ impl BloomFilter {
     /// False positives are possible but false negatives are not.
     pub fn may_contain(&self, item: &str) -> bool {
         let (a, b) = self.hashes(item);
-        self.bits.get(a).copied().unwrap_or(false)
-            && self.bits.get(b).copied().unwrap_or(false)
+        self.bits.get(a).copied().unwrap_or(false) && self.bits.get(b).copied().unwrap_or(false)
+    }
+
+    /// Convert the bloom filter into a protobuf message.
+    pub fn to_proto(&self) -> BloomProto {
+        BloomProto {
+            bits: self.bits.clone(),
+        }
+    }
+
+    /// Construct a bloom filter from a protobuf message.
+    pub fn from_proto(proto: BloomProto) -> Self {
+        Self { bits: proto.bits }
+    }
+
+    /// Serialize the bloom filter using protobuf encoding.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.to_proto().encode(&mut buf).unwrap();
+        buf
+    }
+
+    /// Reconstruct a bloom filter from protobuf bytes produced by
+    /// [`to_bytes`].
+    pub fn from_bytes(data: &[u8]) -> Self {
+        let proto = BloomProto::decode(data).unwrap();
+        Self::from_proto(proto)
     }
 }

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -27,4 +27,20 @@ impl Storage for LocalStorage {
         let p = self.root.join(path);
         Ok(tokio::fs::read(p).await?)
     }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        let mut out = Vec::new();
+        if !tokio::fs::try_exists(&self.root).await? {
+            return Ok(out);
+        }
+        let mut dir = tokio::fs::read_dir(&self.root).await?;
+        while let Some(entry) = dir.next_entry().await? {
+            let name = entry.file_name();
+            let name = name.to_string_lossy().to_string();
+            if name.starts_with(prefix) {
+                out.push(name);
+            }
+        }
+        Ok(out)
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 pub trait Storage: Send + Sync {
     async fn put(&self, path: &str, data: Vec<u8>) -> Result<(), StorageError>;
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError>;
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError>;
 }
 
 #[async_trait]
@@ -16,6 +17,10 @@ impl Storage for Box<dyn Storage> {
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
         (**self).get(path).await
     }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        (**self).list(prefix).await
+    }
 }
 
 #[async_trait]
@@ -26,6 +31,10 @@ impl Storage for Arc<dyn Storage> {
 
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
         (**self).get(path).await
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        (**self).list(prefix).await
     }
 }
 

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -52,4 +52,19 @@ impl Storage for S3Storage {
         }
         Ok(resp.bytes().to_vec())
     }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        let results = self
+            .bucket
+            .list(prefix.to_string(), None)
+            .await
+            .map_err(|e| StorageError::Io(Error::new(ErrorKind::Other, e.to_string())))?;
+        let mut out = Vec::new();
+        for res in results {
+            for obj in res.contents {
+                out.push(obj.key);
+            }
+        }
+        Ok(out)
+    }
 }

--- a/src/zonemap.rs
+++ b/src/zonemap.rs
@@ -1,9 +1,18 @@
 /// Zone map summarizing the minimum and maximum keys seen.
+use prost::Message;
 #[derive(Default)]
 pub struct ZoneMap {
     /// Smallest key observed.
     pub min: Option<String>,
     /// Largest key observed.
+    pub max: Option<String>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ZoneMapProto {
+    #[prost(string, optional, tag = "1")]
+    pub min: Option<String>,
+    #[prost(string, optional, tag = "2")]
     pub max: Option<String>,
 }
 
@@ -13,12 +22,12 @@ impl ZoneMap {
         match self.min.as_deref() {
             Some(min) if key < min => self.min = Some(key.to_string()),
             None => self.min = Some(key.to_string()),
-            _ => {},
+            _ => {}
         }
         match self.max.as_deref() {
             Some(max) if key > max => self.max = Some(key.to_string()),
             None => self.max = Some(key.to_string()),
-            _ => {},
+            _ => {}
         }
     }
 
@@ -31,5 +40,33 @@ impl ZoneMap {
             _ => true,
         }
     }
-}
 
+    /// Convert the zone map into a protobuf message.
+    pub fn to_proto(&self) -> ZoneMapProto {
+        ZoneMapProto {
+            min: self.min.clone(),
+            max: self.max.clone(),
+        }
+    }
+
+    /// Construct a zone map from a protobuf message.
+    pub fn from_proto(proto: ZoneMapProto) -> Self {
+        Self {
+            min: proto.min,
+            max: proto.max,
+        }
+    }
+
+    /// Serialize the zone map using protobuf encoding.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        self.to_proto().encode(&mut buf).unwrap();
+        buf
+    }
+
+    /// Reconstruct a zone map from protobuf bytes produced by [`to_bytes`].
+    pub fn from_bytes(data: &[u8]) -> Self {
+        let proto = ZoneMapProto::decode(data).unwrap();
+        Self::from_proto(proto)
+    }
+}

--- a/tests/sstable_local_test.rs
+++ b/tests/sstable_local_test.rs
@@ -8,6 +8,10 @@ async fn sstable_local_roundtrip() {
     let table = SsTable::create("data.tbl", &entries, &storage)
         .await
         .unwrap();
-    let res = table.get("k", &storage).await.unwrap();
+    let loaded = SsTable::load("data.tbl", &storage).await.unwrap();
+    assert_eq!(loaded.bloom.to_bytes(), table.bloom.to_bytes());
+    assert_eq!(loaded.zone_map.min, table.zone_map.min);
+    assert_eq!(loaded.zone_map.max, table.zone_map.max);
+    let res = loaded.get("k", &storage).await.unwrap();
     assert_eq!(res, Some(b"v".to_vec()));
 }

--- a/tests/sstable_recovery_test.rs
+++ b/tests/sstable_recovery_test.rs
@@ -1,0 +1,22 @@
+use cass::{
+    Database,
+    storage::{Storage, local::LocalStorage},
+};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn reload_existing_sstables_on_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let wal = "wal.log";
+    {
+        let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
+        let db = Database::new(storage, wal).await.unwrap();
+        db.insert("k1".to_string(), b"v1".to_vec()).await;
+        db.flush().await.unwrap();
+    }
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
+    let db = Database::new(storage, wal).await.unwrap();
+    let v1 = db.get("k1").await.map(|b| b[8..].to_vec());
+    assert_eq!(v1, Some(b"v1".to_vec()));
+}

--- a/tests/wal_error_test.rs
+++ b/tests/wal_error_test.rs
@@ -18,6 +18,10 @@ impl Storage for BadStorage {
         // return invalid WAL data to trigger a parse error
         Ok(b"bad\t@@\n".to_vec())
     }
+
+    async fn list(&self, _prefix: &str) -> Result<Vec<String>, StorageError> {
+        Ok(Vec::new())
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- load previously flushed SSTables by enumerating storage during Database startup
- add list capability to storage trait and implement for local and S3 backends
- use Protobuf to persist BloomFilter and ZoneMap metadata in sidecar files and restore them on load
- test SSTable recovery and metadata persistence

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4104ab20083248b8216ef7ad2f1df