### PR TITLE
Add dynamic self health monitoring with panic endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ The server exposes a couple of helper endpoints useful during testing:
 
 - `POST /flush` instructs every node in the cluster to flush its in-memory
   memtable to an on-disk SSTable.
-- `POST /flip` toggles the health status of the node receiving the request,
-  switching it between healthy and unhealthy. The node's `node_health`
-  Prometheus gauge reports `1` when healthy and `0` when unhealthy.
+- `POST /panic` forces the node receiving the request to report itself as
+  unhealthy for 60 seconds. Outside of panic mode a node is considered
+  unhealthy when its local storage has less than 5% free space remaining.
+  The `node_health` Prometheus gauge exposes the current status (`1` for
+  healthy, `0` for unhealthy).
 
 ## Monitoring
 

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -1,6 +1,6 @@
 use super::{Storage, StorageError};
 use async_trait::async_trait;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub struct LocalStorage {
     root: PathBuf,
@@ -26,5 +26,9 @@ impl Storage for LocalStorage {
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
         let p = self.root.join(path);
         Ok(tokio::fs::read(p).await?)
+    }
+
+    fn local_path(&self) -> Option<&Path> {
+        Some(&self.root)
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,10 +1,13 @@
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 #[async_trait]
 pub trait Storage: Send + Sync {
     async fn put(&self, path: &str, data: Vec<u8>) -> Result<(), StorageError>;
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError>;
+    fn local_path(&self) -> Option<&Path> {
+        None
+    }
 }
 
 #[async_trait]
@@ -16,6 +19,10 @@ impl Storage for Box<dyn Storage> {
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
         (**self).get(path).await
     }
+
+    fn local_path(&self) -> Option<&Path> {
+        (**self).local_path()
+    }
 }
 
 #[async_trait]
@@ -26,6 +33,10 @@ impl Storage for Arc<dyn Storage> {
 
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
         (**self).get(path).await
+    }
+
+    fn local_path(&self) -> Option<&Path> {
+        (**self).local_path()
     }
 }
 

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -48,13 +48,13 @@ async fn health_info_reports_tokens() {
 }
 
 #[tokio::test]
-async fn flip_health_toggles_self() {
+async fn panic_makes_self_unhealthy_temporarily() {
     let self_addr = "http://127.0.0.1:4000".to_string();
     let cluster = build_cluster(Vec::new(), 1, 1, &self_addr).await;
     assert!(cluster.is_alive(&self_addr).await);
-    assert!(!cluster.flip_health().await);
+    cluster.panic_for(Duration::from_secs(1)).await;
     assert!(!cluster.is_alive(&self_addr).await);
-    assert!(cluster.flip_health().await);
+    tokio::time::sleep(Duration::from_millis(1500)).await;
     assert!(cluster.is_alive(&self_addr).await);
 }
 


### PR DESCRIPTION
## Summary
- Evaluate node health based on local disk space instead of CPU and memory
- Add `local_path` hook for storage backends and implement for local storage
- Track panic state in self_healthy and expose it via Prometheus

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4157cad988324a18cbc710b30a5c0