### PR TITLE
feat: pretty-print REPL tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,17 +114,17 @@ INSERT 1 row
 > INSERT INTO orders VALUES ('nike', 'def456', '2025-08-26')
 INSERT 1 row
 > SELECT * FROM orders WHERE customer_id = 'nike'
-customer_id | order_date | order_id
-nike | 2025-08-25 | abc123
-nike | 2025-08-26 | def456
+  customer_id order_date  order_id
+0 nike        2025-08-25  abc123
+1 nike        2025-08-26  def456
 (2 rows)
 > SELECT COUNT(1) FROM orders WHERE customer_id = 'nike'
-count
-2
+ count
+0 2
 (1 rows)
 > SELECT * FROM orders WHERE customer_id = 'nike' AND order_id = 'abc123'
-customer_id | order_date | order_id
-nike | 2025-08-25 | abc123
+  customer_id order_date  order_id
+0 nike        2025-08-25  abc123
 (1 rows)
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,13 +58,33 @@ fn print_rows(rows: &[RpcRow]) {
         .collect();
     cols.sort();
     cols.dedup();
-    println!("{}", cols.join(" | "));
-    for row in rows {
-        let mut vals: Vec<String> = Vec::new();
-        for c in &cols {
-            vals.push(row.columns.get(c).cloned().unwrap_or_default());
+
+    let index_width = rows.len().to_string().len();
+    let col_widths: Vec<usize> = cols
+        .iter()
+        .map(|c| {
+            let max_val = rows
+                .iter()
+                .map(|r| r.columns.get(c).map(|v| v.len()).unwrap_or(0))
+                .max()
+                .unwrap_or(0);
+            std::cmp::max(c.len(), max_val)
+        })
+        .collect();
+
+    let mut header = format!("{:>width$}", "", width = index_width);
+    for (c, w) in cols.iter().zip(col_widths.iter()) {
+        header.push_str(&format!(" {:<width$}", c, width = w));
+    }
+    println!("{}", header);
+
+    for (i, row) in rows.iter().enumerate() {
+        let mut line = format!("{:>width$}", i, width = index_width);
+        for (c, w) in cols.iter().zip(col_widths.iter()) {
+            let val = row.columns.get(c).cloned().unwrap_or_default();
+            line.push_str(&format!(" {:<width$}", val, width = w));
         }
-        println!("{}", vals.join(" | "));
+        println!("{}", line);
     }
     println!("({} rows)", rows.len());
 }


### PR DESCRIPTION
## Summary
- format REPL query results into aligned tables like pandas head
- update README examples to show table formatting

## Testing
- `cargo fmt`
- `cargo test` *(fails: union_and_lww_across_replicas)*

------
https://chatgpt.com/codex/tasks/task_e_68ae89541b7883249d4a643f73a198d8