### PR TITLE
Use .tbl extension for SSTable disk usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -332,7 +332,7 @@ fn sstable_disk_usage(dir: &str) -> u64 {
                 let p = entry.path();
                 if p.is_dir() {
                     size += visit(&p);
-                } else if p.extension().and_then(|e| e.to_str()) == Some("sst") {
+                } else if p.extension().and_then(|e| e.to_str()) == Some("tbl") {
                     if let Ok(meta) = entry.metadata() {
                         size += meta.len();
                     }


### PR DESCRIPTION
## Summary
- account for `.tbl` SSTable files when reporting disk usage

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9786ad24832483d25e75d1085648