### PR TITLE
Add append support to storage and optimize WAL writes

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,6 +6,11 @@ pub trait Storage: Send + Sync {
     async fn put(&self, path: &str, data: Vec<u8>) -> Result<(), StorageError>;
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError>;
 
+    /// Append `data` to the object at `path` without rewriting the existing
+    /// contents. Backends may implement this efficiently or fall back to
+    /// reading and rewriting the entire object.
+    async fn append(&self, path: &str, data: &[u8]) -> Result<(), StorageError>;
+
     fn local_path(&self) -> Option<&Path> {
         None
     }
@@ -21,6 +26,10 @@ impl Storage for Box<dyn Storage> {
 
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
         (**self).get(path).await
+    }
+
+    async fn append(&self, path: &str, data: &[u8]) -> Result<(), StorageError> {
+        (**self).append(path, data).await
     }
 
     fn local_path(&self) -> Option<&Path> {
@@ -39,6 +48,10 @@ impl Storage for Arc<dyn Storage> {
 
     async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
         (**self).get(path).await
+    }
+
+    async fn append(&self, path: &str, data: &[u8]) -> Result<(), StorageError> {
+        (**self).append(path, data).await
     }
 
     fn local_path(&self) -> Option<&Path> {

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -53,6 +53,13 @@ impl Storage for S3Storage {
         Ok(resp.bytes().to_vec())
     }
 
+    async fn append(&self, path: &str, data: &[u8]) -> Result<(), StorageError> {
+        // S3 does not support appends; fall back to read-modify-write.
+        let mut existing = self.get(path).await.unwrap_or_default();
+        existing.extend_from_slice(data);
+        self.put(path, existing).await
+    }
+
     async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
         let results = self
             .bucket

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -63,10 +63,11 @@ impl Wal {
     /// backend.
     pub async fn append(&self, data: &[u8]) -> std::io::Result<()> {
         let mut buf = self.buf.lock().await;
+        let start = buf.len();
         buf.extend_from_slice(data);
         buf.push(b'\n');
         self.storage
-            .put(&self.path, buf.clone())
+            .append(&self.path, &buf[start..])
             .await
             .map_err(map_err)?;
         Ok(())

--- a/tests/wal_error_test.rs
+++ b/tests/wal_error_test.rs
@@ -19,6 +19,10 @@ impl Storage for BadStorage {
         Ok(b"bad\t@@\n".to_vec())
     }
 
+    async fn append(&self, _path: &str, _data: &[u8]) -> Result<(), StorageError> {
+        Ok(())
+    }
+
     async fn list(&self, _prefix: &str) -> Result<Vec<String>, StorageError> {
         Ok(Vec::new())
     }

--- a/tests/wal_stress_test.rs
+++ b/tests/wal_stress_test.rs
@@ -1,0 +1,51 @@
+use async_trait::async_trait;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use tokio::sync::Mutex;
+
+use cass::storage::{Storage, StorageError};
+use cass::wal::Wal;
+
+#[derive(Default)]
+struct CountingStorage {
+    data: Mutex<Vec<u8>>,
+    bytes: AtomicUsize,
+}
+
+#[async_trait]
+impl Storage for CountingStorage {
+    async fn put(&self, _path: &str, data: Vec<u8>) -> Result<(), StorageError> {
+        let mut buf = self.data.lock().await;
+        *buf = data.clone();
+        self.bytes.fetch_add(data.len(), Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn get(&self, _path: &str) -> Result<Vec<u8>, StorageError> {
+        Ok(self.data.lock().await.clone())
+    }
+
+    async fn append(&self, _path: &str, data: &[u8]) -> Result<(), StorageError> {
+        let mut buf = self.data.lock().await;
+        buf.extend_from_slice(data);
+        self.bytes.fetch_add(data.len(), Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn list(&self, _prefix: &str) -> Result<Vec<String>, StorageError> {
+        Ok(Vec::new())
+    }
+}
+
+#[tokio::test]
+async fn wal_append_stress_no_bloat() {
+    let storage = Arc::new(CountingStorage::default());
+    let wal = Wal::new(storage.clone(), "wal.log").await.unwrap().0;
+    for _ in 0..1000 {
+        wal.append(b"abc").await.unwrap();
+    }
+    // each append writes "abc\n" -> 4 bytes
+    assert_eq!(storage.bytes.load(Ordering::SeqCst), 4 * 1000);
+}


### PR DESCRIPTION
## Summary
- extend storage trait with an append API
- implement append for local and S3 backends
- update WAL to append new bytes and add stress test

## Testing
- `cargo test`
- `cargo test wal_append_stress_no_bloat --test wal_stress_test`


------
https://chatgpt.com/codex/tasks/task_e_68ae97c3cd7883248fe7ef2720a34e04