### PR TITLE
Add SSTable index and lookup benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,9 +346,11 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "clap",
+ "criterion",
  "futures",
  "hyper 0.14.32",
  "hyper-util",
+ "memmap2",
  "murmur3",
  "once_cell",
  "prometheus",
@@ -367,6 +375,12 @@ dependencies = [
  "tracing-subscriber",
  "url",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -399,6 +413,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -545,6 +586,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
 dependencies = [
  "crc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -897,6 +974,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1006,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1318,10 +1411,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1447,6 +1560,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1593,6 +1715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1832,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,7 +1934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -1798,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -2450,6 +2606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,6 +2969,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3183,6 +3358,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3528,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,7 @@ criterion = "0.5"
 [build-dependencies]
 tonic-build = "0.12"
 protoc-bin-vendored = "3"
+
+[[bench]]
+name = "lookup"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,14 @@ rustyline = "12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tower-http = { version = "0.6", features = ["trace"] }
+memmap2 = "0.9"
 
 [dev-dependencies]
 tempfile = "3"
 s3s = "0.12.0-minio-preview.3"
 s3s-fs = "0.12.0-minio-preview.3"
 hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
+criterion = "0.5"
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -1,0 +1,68 @@
+use base64::{Engine, engine::general_purpose::STANDARD};
+use cass::{
+    sstable::SsTable,
+    storage::{Storage, StorageError, local::LocalStorage},
+};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+const SEP: u8 = b'\t';
+const NL: u8 = b'\n';
+
+async fn old_lookup(
+    path: &str,
+    storage: &LocalStorage,
+    key: &str,
+) -> Result<Option<Vec<u8>>, StorageError> {
+    let raw = storage.get(path).await?;
+    let lines: Vec<&[u8]> = raw
+        .split(|b| *b == NL)
+        .filter(|line| !line.is_empty())
+        .collect();
+    let mut lo = 0;
+    let mut hi = lines.len();
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        let line = lines[mid];
+        if let Some(pos) = line.iter().position(|b| *b == SEP) {
+            match line[..pos].cmp(key.as_bytes()) {
+                std::cmp::Ordering::Less => lo = mid + 1,
+                std::cmp::Ordering::Greater => hi = mid,
+                std::cmp::Ordering::Equal => {
+                    let val = STANDARD
+                        .decode(&line[pos + 1..])
+                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    return Ok(Some(val));
+                }
+            }
+        } else {
+            break;
+        }
+    }
+    Ok(None)
+}
+
+fn bench_lookup(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+    let entries: Vec<(String, Vec<u8>)> = (0..1000)
+        .map(|i| (format!("k{:04}", i), vec![b'x'; 8]))
+        .collect();
+    let table = rt
+        .block_on(SsTable::create("table.tbl", &entries, &storage))
+        .unwrap();
+    let key = "k0500";
+    c.bench_function("lookup_indexed", |b| {
+        b.iter(|| {
+            rt.block_on(table.get(key, &storage)).unwrap();
+        })
+    });
+    c.bench_function("lookup_old", |b| {
+        b.iter(|| {
+            rt.block_on(old_lookup(&table.path, &storage, key)).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_lookup);
+criterion_main!(benches);

--- a/src/sstable.rs
+++ b/src/sstable.rs
@@ -4,10 +4,16 @@ use crate::zonemap::{ZoneMap, ZoneMapProto};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use prost::Message;
+use std::fs::File;
+
+use memmap2::MmapOptions;
 
 // field delimiters within on-disk table files
 const SEP: u8 = b'\t';
 const NL: u8 = b'\n';
+
+// build an index entry every N keys
+const INDEX_INTERVAL: usize = 16;
 
 fn meta_path(path: &str) -> String {
     if let Some(base) = path.strip_suffix(".tbl") {
@@ -26,6 +32,8 @@ pub struct SsTable {
     pub bloom: BloomFilter,
     /// Zone map storing min/max keys for coarse filtering.
     pub zone_map: ZoneMap,
+    /// Sparse index mapping keys to approximate offsets in the table file.
+    pub index: Vec<(String, u64)>,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -34,6 +42,16 @@ struct TableMeta {
     bloom: Option<BloomProto>,
     #[prost(message, optional, tag = "2")]
     zone_map: Option<ZoneMapProto>,
+    #[prost(message, repeated, tag = "3")]
+    index: Vec<IndexEntryProto>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct IndexEntryProto {
+    #[prost(string, tag = "1")]
+    key: String,
+    #[prost(uint64, tag = "2")]
+    offset: u64,
 }
 
 impl SsTable {
@@ -43,6 +61,7 @@ impl SsTable {
             path: path.into(),
             bloom: BloomFilter::new(1024),
             zone_map: ZoneMap::default(),
+            index: Vec::new(),
         }
     }
 
@@ -59,7 +78,12 @@ impl SsTable {
         let mut bloom = BloomFilter::new(1024);
         let mut zone_map = ZoneMap::default();
         let mut data = Vec::new();
-        for (k, v) in &sorted {
+        let mut index = Vec::new();
+        let mut offset: u64 = 0;
+        for (i, (k, v)) in sorted.iter().enumerate() {
+            if i % INDEX_INTERVAL == 0 {
+                index.push((k.clone(), offset));
+            }
             // update auxiliary structures
             bloom.insert(k);
             zone_map.update(k);
@@ -69,12 +93,20 @@ impl SsTable {
             let enc = STANDARD.encode(v);
             data.extend_from_slice(enc.as_bytes());
             data.push(NL);
+            offset = data.len() as u64;
         }
         storage.put(&path, data).await?;
         let meta_path = meta_path(&path);
         let meta = TableMeta {
             bloom: Some(bloom.to_proto()),
             zone_map: Some(zone_map.to_proto()),
+            index: index
+                .iter()
+                .map(|(k, o)| IndexEntryProto {
+                    key: k.clone(),
+                    offset: *o,
+                })
+                .collect(),
         };
         let mut buf = Vec::new();
         meta.encode(&mut buf).unwrap();
@@ -83,6 +115,7 @@ impl SsTable {
             path,
             bloom,
             zone_map,
+            index,
         })
     }
 
@@ -100,28 +133,39 @@ impl SsTable {
                     .map(BloomFilter::from_proto)
                     .unwrap_or_else(|| BloomFilter::new(1024));
                 let zone_map = meta.zone_map.map(ZoneMap::from_proto).unwrap_or_default();
+                let index = meta.index.into_iter().map(|e| (e.key, e.offset)).collect();
                 return Ok(Self {
                     path,
                     bloom,
                     zone_map,
+                    index,
                 });
             }
         }
         let raw = storage.get(&path).await?;
         let mut bloom = BloomFilter::new(1024);
         let mut zone_map = ZoneMap::default();
+        let mut index = Vec::new();
+        let mut offset: u64 = 0;
+        let mut i = 0;
         for line in raw.split(|b| *b == NL).filter(|l| !l.is_empty()) {
             if let Some(pos) = line.iter().position(|b| *b == SEP) {
                 let key = std::str::from_utf8(&line[..pos])
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                 bloom.insert(key);
                 zone_map.update(key);
+                if i % INDEX_INTERVAL == 0 {
+                    index.push((key.to_string(), offset));
+                }
+                offset += line.len() as u64 + 1; // include newline
+                i += 1;
             }
         }
         Ok(Self {
             path,
             bloom,
             zone_map,
+            index,
         })
     }
 
@@ -138,14 +182,25 @@ impl SsTable {
         if !self.zone_map.contains(key) || !self.bloom.may_contain(key) {
             return Ok(None);
         }
+        let offset = self.seek_offset(key);
+        if let Some(root) = storage.local_path() {
+            let path = root.join(&self.path);
+            let file = File::open(path)?;
+            // memory-map the file for efficient slicing
+            let mmap = unsafe { MmapOptions::new().map(&file)? };
+            if let Some(enc) = Self::scan_from(&mmap[offset as usize..], key) {
+                let val = STANDARD
+                    .decode(enc)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                return Ok(Some(val));
+            }
+            return Ok(None);
+        }
+        // fallback to reading entire file from storage
         let raw = storage.get(&self.path).await?;
-        let lines: Vec<&[u8]> = raw
-            .split(|b| *b == NL)
-            .filter(|line| !line.is_empty())
-            .collect();
-        if let Some(encoded) = Self::binary_search(&lines, key) {
+        if let Some(enc) = Self::scan_from(&raw[offset as usize..], key) {
             let val = STANDARD
-                .decode(encoded)
+                .decode(enc)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             return Ok(Some(val));
         }
@@ -158,21 +213,48 @@ impl SsTable {
     /// lines must be sorted by key in ascending order. When the target key is
     /// found the encoded value slice (the bytes after the separator) is
     /// returned. If the key is not present `None` is returned.
-    fn binary_search<'a>(lines: &'a [&'a [u8]], key: &str) -> Option<&'a [u8]> {
+
+    /// Find the starting byte offset for a given key using the sparse index.
+    fn seek_offset(&self, key: &str) -> u64 {
+        if self.index.is_empty() {
+            return 0;
+        }
         let mut lo = 0;
-        let mut hi = lines.len();
+        let mut hi = self.index.len();
         while lo < hi {
             let mid = (lo + hi) / 2;
-            let line = lines[mid];
+            match self.index[mid].0.as_str().cmp(key) {
+                std::cmp::Ordering::Less => lo = mid + 1,
+                std::cmp::Ordering::Greater => hi = mid,
+                std::cmp::Ordering::Equal => return self.index[mid].1,
+            }
+        }
+        if lo == 0 { 0 } else { self.index[lo - 1].1 }
+    }
+
+    /// Scan forward from `slice` searching for `key` and return the encoded
+    /// value slice when found.
+    fn scan_from<'a>(mut slice: &'a [u8], key: &str) -> Option<&'a [u8]> {
+        while !slice.is_empty() {
+            let nl_pos = match slice.iter().position(|b| *b == NL) {
+                Some(p) => p,
+                None => return None,
+            };
+            let line = &slice[..nl_pos];
             if let Some(pos) = line.iter().position(|b| *b == SEP) {
                 let key_bytes = &line[..pos];
                 match key_bytes.cmp(key.as_bytes()) {
-                    std::cmp::Ordering::Less => lo = mid + 1,
-                    std::cmp::Ordering::Greater => hi = mid,
-                    std::cmp::Ordering::Equal => return Some(&line[pos + 1..]),
+                    std::cmp::Ordering::Less => {
+                        slice = &slice[nl_pos + 1..];
+                        continue;
+                    }
+                    std::cmp::Ordering::Greater => return None,
+                    std::cmp::Ordering::Equal => {
+                        return Some(&line[pos + 1..]);
+                    }
                 }
             } else {
-                break;
+                return None;
             }
         }
         None


### PR DESCRIPTION
## Summary
- build sparse on-disk index for SSTables and persist in table metadata
- seek to indexed offset and memory-map files during SsTable::get
- add criterion benchmark comparing indexed and legacy lookups

## Testing
- `cargo test`
- `cargo bench --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68ae97ec378c832491710d796db46f22