### PR TITLE
Add local performance comparison harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
 dependencies = [
  "http 1.3.1",
  "log",
- "rustls",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "url",
@@ -219,7 +219,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -240,7 +240,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -348,6 +348,7 @@ dependencies = [
  "prometheus",
  "prost",
  "protoc-bin-vendored",
+ "reqwest 0.11.27",
  "rust-s3",
  "rustyline",
  "s3s",
@@ -489,6 +490,16 @@ name = "const-str"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451d0640545a0553814b4c646eb549343561618838e9b42495f466131fe3ad49"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -655,6 +666,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endian-type"
@@ -1087,6 +1107,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -1094,10 +1128,10 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
  "webpki-roots 1.0.2",
 ]
@@ -1934,7 +1968,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.31",
  "socket2 0.5.10",
  "thiserror 2.0.14",
  "tokio",
@@ -1954,7 +1988,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.14",
@@ -2156,6 +2190,47 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.25.4",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
@@ -2168,21 +2243,21 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
  "tower-http",
@@ -2240,7 +2315,7 @@ dependencies = [
  "md5",
  "percent-encoding",
  "quick-xml 0.36.2",
- "reqwest",
+ "reqwest 0.12.23",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2301,6 +2376,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
@@ -2308,9 +2395,18 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2321,6 +2417,16 @@ checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2409,7 +2515,7 @@ dependencies = [
  "sha2 0.11.0-pre.5",
  "smallvec",
  "std-next",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "thiserror 2.0.14",
  "time",
  "tokio",
@@ -2454,6 +2560,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -2661,6 +2777,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2692,6 +2814,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2852,11 +2995,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -2971,7 +3124,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3312,6 +3465,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
@@ -3649,6 +3808,16 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rustyline = "12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tower-http = { version = "0.6", features = ["trace"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -156,3 +156,13 @@ counts, peer health, RAM and CPU usage, and SSTable disk usage.
 There is also a preconfigured dashboard with basic metrics from all instances. Screenshot below:
 
 <img width="1257" height="821" alt="Screenshot 2025-08-17 at 11 48 28 PM" src="https://github.com/user-attachments/assets/cbaf71aa-c726-4c6a-a1eb-422060aecd0a" />
+
+## Performance Benchmarking
+
+The repository includes a simple harness for comparing write and read throughput of `cass` against a reference Apache Cassandra node.
+
+```bash
+scripts/perf_compare.sh         # runs both databases and stores metrics in ./perf-results
+```
+
+The script starts a three-node `cass` cluster and uses the example program `perf_client` to drive load. Metrics from the first `cass` node and `nodetool` statistics from Cassandra are written to the `perf-results` directory for analysis.

--- a/examples/perf_client.rs
+++ b/examples/perf_client.rs
@@ -1,0 +1,66 @@
+use std::time::Instant;
+
+use cass::rpc::{QueryRequest, cass_client::CassClient};
+use clap::Parser;
+use tokio::fs;
+
+#[derive(Parser)]
+struct Args {
+    /// gRPC endpoint of the cass node
+    #[clap(long, default_value = "http://127.0.0.1:8080")]
+    node: String,
+    /// Number of write/read operations to issue
+    #[clap(long, default_value_t = 1000)]
+    ops: usize,
+    /// Metrics endpoint for the node
+    #[clap(long, default_value = "http://127.0.0.1:9090/metrics")]
+    metrics_endpoint: String,
+    /// Optional path to write Prometheus metrics after the run
+    #[clap(long)]
+    metrics_out: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let mut client = CassClient::connect(args.node.clone()).await?;
+    client
+        .query(QueryRequest {
+            sql: "CREATE TABLE IF NOT EXISTS perf (k INT PRIMARY KEY, v INT)".into(),
+        })
+        .await?;
+
+    let start = Instant::now();
+    for i in 0..args.ops {
+        let sql = format!("INSERT INTO perf VALUES ({}, {})", i, i);
+        client.query(QueryRequest { sql }).await?;
+    }
+    let write_dur = start.elapsed();
+
+    let start = Instant::now();
+    for i in 0..args.ops {
+        let sql = format!("SELECT * FROM perf WHERE k = {}", i);
+        client.query(QueryRequest { sql }).await?;
+    }
+    let read_dur = start.elapsed();
+
+    println!(
+        "cass writes: ops={} ms={} ops/sec={:.2}",
+        args.ops,
+        write_dur.as_millis(),
+        (args.ops as f64) / write_dur.as_secs_f64()
+    );
+    println!(
+        "cass reads: ops={} ms={} ops/sec={:.2}",
+        args.ops,
+        read_dur.as_millis(),
+        (args.ops as f64) / read_dur.as_secs_f64()
+    );
+
+    if let Some(out) = args.metrics_out {
+        let body = reqwest::get(&args.metrics_endpoint).await?.text().await?;
+        fs::write(out, body).await?;
+    }
+
+    Ok(())
+}

--- a/scripts/perf_compare.sh
+++ b/scripts/perf_compare.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPS=${OPS:-1000}
+OUTDIR=${OUTDIR:-perf-results}
+CASS_NODE=${CASS_NODE:-http://localhost:8080}
+
+mkdir -p "$OUTDIR"
+
+# Start a three-node cass cluster and Prometheus
+echo "Starting cass cluster..."
+docker compose up -d cass1 cass2 cass3 prometheus >/dev/null
+# Give the nodes a moment to come up
+sleep 10
+cargo run --example perf_client -- --node "$CASS_NODE" --ops "$OPS" > "$OUTDIR/cass.log"
+# Capture Prometheus metrics from the first node
+docker compose exec cass1 curl -s http://localhost:9080/metrics > "$OUTDIR/cass_metrics.prom"
+docker compose down >/dev/null
+
+# Start Apache Cassandra
+echo "Starting Apache Cassandra..."
+docker run -d --name perf-cassandra -p 9042:9042 cassandra:4.1 >/dev/null
+# Wait until Cassandra is ready
+until docker exec perf-cassandra nodetool status >/dev/null 2>&1; do
+  echo "waiting for cassandra..."
+  sleep 5
+done
+
+docker exec perf-cassandra /opt/cassandra/tools/bin/cassandra-stress write n=$OPS -mode native cql3 > "$OUTDIR/cassandra_write.log"
+docker exec perf-cassandra /opt/cassandra/tools/bin/cassandra-stress read n=$OPS -mode native cql3 > "$OUTDIR/cassandra_read.log"
+docker exec perf-cassandra nodetool tpstats > "$OUTDIR/cassandra_metrics.log"
+docker rm -f perf-cassandra >/dev/null
+
+echo "Results stored under $OUTDIR"


### PR DESCRIPTION
## Summary
- add `perf_client` example to issue write/read workloads against a cass node and optionally dump metrics
- introduce `scripts/perf_compare.sh` to benchmark cass against Apache Cassandra and collect outputs
- document performance benchmarking harness in README
- fix harness to run a three-node cass cluster, gather metrics correctly, and use valid `cassandra-stress` path

## Testing
- `cargo test`
- `OPS=1 scripts/perf_compare.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68aea459e27c8324aef9eab4017cc6af