### PR TITLE
Add TRUNCATE TABLE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The built-in SQL engine understands a small subset of SQL:
 - `SELECT` with optional `WHERE` filters, `ORDER BY`, `GROUP BY`,
   `DISTINCT`, simple aggregate functions (`COUNT`, `MIN`, `MAX`, `SUM`)
   and `LIMIT`
-- Table management statements such as `CREATE TABLE`, `DROP TABLE` and
-  `SHOW TABLES`
+- Table management statements such as `CREATE TABLE`, `DROP TABLE`,
+  `TRUNCATE TABLE`, and `SHOW TABLES`
 
 Note on creating [partition and clustering keys](https://cassandra.apache.org/doc/4.0/cassandra/data_modeling/intro.html#partitions):
 the first column in `PRIMARY KEY(...)` will be the partition key, subsequent columns will be indexed as clustering keys.

--- a/src/query.rs
+++ b/src/query.rs
@@ -175,6 +175,19 @@ impl SqlEngine {
                     Err(QueryError::Unsupported)
                 }
             }
+            Statement::Truncate { table_names, .. } => {
+                if let Some(target) = table_names.first() {
+                    let ns = object_name_to_ns(&target.name).ok_or(QueryError::Unsupported)?;
+                    db.clear_ns(&ns).await;
+                    Ok(QueryOutput::Mutation {
+                        op: "TRUNCATE".to_string(),
+                        unit: "table".to_string(),
+                        count: 1,
+                    })
+                } else {
+                    Err(QueryError::Unsupported)
+                }
+            }
             Statement::Query(q) => self.exec_query(db, q, meta).await,
             _ => Err(QueryError::Unsupported),
         }

--- a/tests/query_truncate_test.rs
+++ b/tests/query_truncate_test.rs
@@ -1,0 +1,42 @@
+use cass::storage::{Storage, local::LocalStorage};
+use cass::{Database, SqlEngine, query::QueryOutput};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn truncate_table_removes_rows() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(tmp.path()));
+    let db = Database::new(storage, "wal.log").await.unwrap();
+    let engine = SqlEngine::new();
+
+    engine
+        .execute(&db, "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))")
+        .await
+        .unwrap();
+
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('1','a')")
+        .await
+        .unwrap();
+
+    let before = engine
+        .execute(&db, "SELECT * FROM t WHERE id='1'")
+        .await
+        .unwrap();
+    let rows = match before {
+        QueryOutput::Rows(r) => r,
+        _ => panic!("unexpected"),
+    };
+    assert_eq!(rows.len(), 1);
+
+    engine.execute(&db, "TRUNCATE TABLE t").await.unwrap();
+
+    let after = engine
+        .execute(&db, "SELECT * FROM t WHERE id='1'")
+        .await
+        .unwrap();
+    match after {
+        QueryOutput::Rows(r) => assert!(r.is_empty()),
+        _ => panic!("unexpected"),
+    }
+}


### PR DESCRIPTION
## Summary
- add SQL engine support for `TRUNCATE TABLE`
- document `TRUNCATE TABLE` in README
- test that truncation removes all rows without dropping schema

## Testing
- `cargo test`
- `cargo test truncate_table_removes_rows --test query_truncate_test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b3a525b040832481c67581855541df