### PR TITLE
Add tunable read consistency with hinted handoff and read repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Toy/experimental clone of [Apache Cassandra](https://en.wikipedia.org/wiki/Apach
 - **Deployment:** Dockerfile and docker-compose for containerized deployment and local testing
 - **Scalability:** Horizontally scalable
 - **Gossip:** Cluster membership and liveness detection via gossip with health checks
+- **Consistency:** Tunable read replica count with hinted handoff and read repair
 
 ## Design tradeoffs
 
@@ -30,8 +31,8 @@ The built-in SQL engine understands a small subset of SQL:
 - `SELECT` with optional `WHERE` filters, `ORDER BY`, `GROUP BY`,
   `DISTINCT`, simple aggregate functions (`COUNT`, `MIN`, `MAX`, `SUM`)
   and `LIMIT`
-- Table management statements such as `CREATE TABLE`, `DROP TABLE` and
-  `SHOW TABLES`
+- Table management statements such as `CREATE TABLE`, `DROP TABLE`,
+  `TRUNCATE TABLE`, and `SHOW TABLES`
 
 Note on creating [partition and clustering keys](https://cassandra.apache.org/doc/4.0/cassandra/data_modeling/intro.html#partitions):
 the first column in `PRIMARY KEY(...)` will be the partition key, subsequent columns will be indexed as clustering keys.
@@ -53,6 +54,7 @@ CREATE TABLE t (
 ```bash
 cargo test            # run unit tests
 cargo run -- server  # start the gRPC server on port 8080
+cargo run -- server --read-consistency 1  # only one healthy replica required for reads
 ```
 
 ### Contributing

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,8 @@ struct ServerArgs {
     rf: usize,
     #[arg(long, default_value_t = 8)]
     vnodes: usize,
+    #[arg(long)]
+    read_consistency: Option<usize>,
 }
 
 #[derive(Copy, Clone, ValueEnum)]
@@ -242,6 +244,7 @@ async fn run_server(args: ServerArgs) -> Result<(), Box<dyn std::error::Error>> 
         args.peer.clone(),
         args.vnodes,
         args.rf,
+        args.read_consistency.unwrap_or(args.rf),
     ));
 
     tl_metrics::try_init_settings(tl_metrics::GlobalSettings {

--- a/src/query.rs
+++ b/src/query.rs
@@ -175,6 +175,19 @@ impl SqlEngine {
                     Err(QueryError::Unsupported)
                 }
             }
+            Statement::Truncate { table_names, .. } => {
+                if let Some(target) = table_names.first() {
+                    let ns = object_name_to_ns(&target.name).ok_or(QueryError::Unsupported)?;
+                    db.clear_ns(&ns).await;
+                    Ok(QueryOutput::Mutation {
+                        op: "TRUNCATE".to_string(),
+                        unit: "table".to_string(),
+                        count: 1,
+                    })
+                } else {
+                    Err(QueryError::Unsupported)
+                }
+            }
             Statement::Query(q) => self.exec_query(db, q, meta).await,
             _ => Err(QueryError::Unsupported),
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -35,6 +35,8 @@ pub enum QueryOutput {
     None,
 }
 
+/// Split the leading 8-byte timestamp from a buffer, returning the timestamp and
+/// the remaining slice.
 fn split_ts(bytes: &[u8]) -> (u64, &[u8]) {
     if bytes.len() < 8 {
         return (0, bytes);
@@ -914,6 +916,8 @@ fn cast_simple(val: &str, data_type: &DataType) -> Option<String> {
 mod tests {
     use sqlparser::ast::{DataType, Expr, Ident, ObjectName, ObjectNamePart, TableFactor, Value};
 
+    /// `split_ts` returns zero and the original slice when the buffer is shorter
+    /// than eight bytes.
     #[test]
     fn split_ts_handles_short_buffers() {
         let buf = [1u8, 2u8, 3u8];
@@ -922,6 +926,7 @@ mod tests {
         assert_eq!(rest, &buf);
     }
 
+    /// `split_ts` extracts the timestamp and remaining bytes from the buffer.
     #[test]
     fn split_ts_parses_timestamp_and_rest() {
         let ts_val: u64 = 42;

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -10,7 +10,7 @@ async fn build_cluster(peers: Vec<String>, vnodes: usize, rf: usize, self_addr: 
     let dir = tempdir().unwrap();
     let storage = Arc::new(LocalStorage::new(dir.path()));
     let db = Arc::new(Database::new(storage, "wal.log").await.unwrap());
-    Cluster::new(db, self_addr.to_string(), peers, vnodes, rf)
+    Cluster::new(db, self_addr.to_string(), peers, vnodes, rf, rf)
 }
 
 #[tokio::test]
@@ -89,7 +89,7 @@ async fn flush_all_flushes_memtable() {
     let storage = Arc::new(LocalStorage::new(dir.path()));
     let db = Arc::new(Database::new(storage, "wal.log").await.unwrap());
     let self_addr = "http://127.0.0.1:5000".to_string();
-    let cluster = Cluster::new(db.clone(), self_addr, Vec::new(), 1, 1);
+    let cluster = Cluster::new(db.clone(), self_addr, Vec::new(), 1, 1, 1);
     db.insert("k".into(), b"v".to_vec()).await;
     assert_eq!(db.memtable().len().await, 1);
     cluster.flush_all().await.unwrap();

--- a/tests/gossip_health_test.rs
+++ b/tests/gossip_health_test.rs
@@ -87,6 +87,11 @@ async fn errors_when_not_enough_healthy_replicas() {
     })
     .await
     .unwrap();
+    c1.query(QueryRequest {
+        sql: "INSERT INTO kv (id, val) VALUES ('x','1')".into(),
+    })
+    .await
+    .unwrap();
 
     child2.kill();
 
@@ -94,7 +99,7 @@ async fn errors_when_not_enough_healthy_replicas() {
     loop {
         let res = c1
             .query(QueryRequest {
-                sql: "INSERT INTO kv (id, val) VALUES ('x','1')".into(),
+                sql: "SELECT val FROM kv WHERE id = 'x'".into(),
             })
             .await;
         if let Err(e) = res {
@@ -103,6 +108,85 @@ async fn errors_when_not_enough_healthy_replicas() {
         }
         if start.elapsed() > Duration::from_secs(2) {
             panic!("replica did not report unhealthy in time");
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    child1.kill();
+}
+
+#[tokio::test]
+async fn read_succeeds_with_lower_consistency() {
+    let base1 = "http://127.0.0.1:18101";
+    let base2 = "http://127.0.0.1:18102";
+    let dir1 = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+
+    let mut child1 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir1.path().to_str().unwrap(),
+        "--node-addr",
+        base1,
+        "--peer",
+        base2,
+        "--rf",
+        "2",
+        "--read-consistency",
+        "1",
+    ]);
+    let mut child2 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir2.path().to_str().unwrap(),
+        "--node-addr",
+        base2,
+        "--peer",
+        base1,
+        "--rf",
+        "2",
+        "--read-consistency",
+        "1",
+    ]);
+
+    for _ in 0..20 {
+        let ok1 = CassClient::connect(base1.to_string()).await.is_ok();
+        let ok2 = CassClient::connect(base2.to_string()).await.is_ok();
+        if ok1 && ok2 {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    let mut c1 = CassClient::connect(base1.to_string()).await.unwrap();
+    c1.query(QueryRequest {
+        sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+    })
+    .await
+    .unwrap();
+    c1.query(QueryRequest {
+        sql: "INSERT INTO kv (id, val) VALUES ('a','1')".into(),
+    })
+    .await
+    .unwrap();
+
+    child2.kill();
+
+    let start = Instant::now();
+    loop {
+        let res = c1
+            .query(QueryRequest {
+                sql: "SELECT val FROM kv WHERE id = 'a'".into(),
+            })
+            .await;
+        if let Ok(resp) = res {
+            if let Some(cass::rpc::query_response::Payload::Rows(rs)) = resp.into_inner().payload {
+                assert_eq!(rs.rows[0].columns.get("val"), Some(&"1".to_string()));
+                break;
+            }
+        }
+        if start.elapsed() > Duration::from_secs(2) {
+            panic!("read did not succeed in time");
         }
         sleep(Duration::from_millis(50)).await;
     }

--- a/tests/gossip_health_test.rs
+++ b/tests/gossip_health_test.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 mod common;
 use common::CassProcess;
 
+/// The health endpoint reports the node's tokens.
 #[tokio::test]
 async fn health_endpoint_reports_tokens() {
     let base = "http://127.0.0.1:18085";
@@ -42,6 +43,7 @@ async fn health_endpoint_reports_tokens() {
     assert_eq!(v["tokens"].as_array().unwrap().len(), 4);
 }
 
+/// Queries fail when the required number of healthy replicas is not met.
 #[tokio::test]
 async fn errors_when_not_enough_healthy_replicas() {
     let base1 = "http://127.0.0.1:18091";
@@ -115,6 +117,7 @@ async fn errors_when_not_enough_healthy_replicas() {
     child1.kill();
 }
 
+/// Lowering the read consistency allows queries to succeed with fewer healthy replicas.
 #[tokio::test]
 async fn read_succeeds_with_lower_consistency() {
     let base1 = "http://127.0.0.1:18101";

--- a/tests/hinted_handoff_test.rs
+++ b/tests/hinted_handoff_test.rs
@@ -6,6 +6,7 @@ use cass::rpc::{QueryRequest, cass_client::CassClient, query_response};
 mod common;
 use common::CassProcess;
 
+/// Hints are replayed once a previously failed node rejoins the cluster.
 #[tokio::test]
 async fn hinted_handoff_replays_when_node_recovers() {
     let base1 = "http://127.0.0.1:18111";

--- a/tests/hinted_handoff_test.rs
+++ b/tests/hinted_handoff_test.rs
@@ -1,0 +1,116 @@
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+use cass::rpc::{QueryRequest, cass_client::CassClient, query_response};
+
+mod common;
+use common::CassProcess;
+
+#[tokio::test]
+async fn hinted_handoff_replays_when_node_recovers() {
+    let base1 = "http://127.0.0.1:18111";
+    let base2 = "http://127.0.0.1:18112";
+    let dir1 = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+
+    let mut child1 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir1.path().to_str().unwrap(),
+        "--node-addr",
+        base1,
+        "--peer",
+        base2,
+        "--rf",
+        "2",
+        "--read-consistency",
+        "1",
+    ]);
+    let mut child2 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir2.path().to_str().unwrap(),
+        "--node-addr",
+        base2,
+        "--peer",
+        base1,
+        "--rf",
+        "2",
+        "--read-consistency",
+        "1",
+    ]);
+
+    for _ in 0..20 {
+        let ok1 = CassClient::connect(base1.to_string()).await.is_ok();
+        let ok2 = CassClient::connect(base2.to_string()).await.is_ok();
+        if ok1 && ok2 {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    let mut c1 = CassClient::connect(base1.to_string()).await.unwrap();
+    c1.query(QueryRequest {
+        sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+    })
+    .await
+    .unwrap();
+
+    child2.kill();
+
+    c1.query(QueryRequest {
+        sql: "INSERT INTO kv (id, val) VALUES ('h','1')".into(),
+    })
+    .await
+    .unwrap();
+
+    child2 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir2.path().to_str().unwrap(),
+        "--node-addr",
+        base2,
+        "--peer",
+        base1,
+        "--rf",
+        "2",
+        "--read-consistency",
+        "1",
+    ]);
+
+    for _ in 0..20 {
+        if CassClient::connect(base2.to_string()).await.is_ok() {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    let start = Instant::now();
+    loop {
+        let _ = c1
+            .query(QueryRequest {
+                sql: "SELECT val FROM kv WHERE id = 'h'".into(),
+            })
+            .await;
+        let mut c2 = CassClient::connect(base2.to_string()).await.unwrap();
+        let resp = c2
+            .query(QueryRequest {
+                sql: "SELECT val FROM kv WHERE id = 'h'".into(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        if let Some(query_response::Payload::Rows(rs)) = resp.payload {
+            if rs.rows.get(0).and_then(|r| r.columns.get("val")) == Some(&"1".to_string()) {
+                break;
+            }
+        }
+        if start.elapsed() > Duration::from_secs(4) {
+            panic!("hint not delivered");
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    child1.kill();
+    child2.kill();
+}

--- a/tests/query_truncate_test.rs
+++ b/tests/query_truncate_test.rs
@@ -2,6 +2,7 @@ use cass::storage::{Storage, local::LocalStorage};
 use cass::{Database, SqlEngine, query::QueryOutput};
 use std::sync::Arc;
 
+/// `TRUNCATE TABLE` deletes all rows while preserving the table definition.
 #[tokio::test]
 async fn truncate_table_removes_rows() {
     let tmp = tempfile::tempdir().unwrap();

--- a/tests/query_truncate_test.rs
+++ b/tests/query_truncate_test.rs
@@ -1,0 +1,42 @@
+use cass::storage::{Storage, local::LocalStorage};
+use cass::{Database, SqlEngine, query::QueryOutput};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn truncate_table_removes_rows() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(tmp.path()));
+    let db = Database::new(storage, "wal.log").await.unwrap();
+    let engine = SqlEngine::new();
+
+    engine
+        .execute(&db, "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))")
+        .await
+        .unwrap();
+
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('1','a')")
+        .await
+        .unwrap();
+
+    let before = engine
+        .execute(&db, "SELECT * FROM t WHERE id='1'")
+        .await
+        .unwrap();
+    let rows = match before {
+        QueryOutput::Rows(r) => r,
+        _ => panic!("unexpected"),
+    };
+    assert_eq!(rows.len(), 1);
+
+    engine.execute(&db, "TRUNCATE TABLE t").await.unwrap();
+
+    let after = engine
+        .execute(&db, "SELECT * FROM t WHERE id='1'")
+        .await
+        .unwrap();
+    match after {
+        QueryOutput::Rows(r) => assert!(r.is_empty()),
+        _ => panic!("unexpected"),
+    }
+}

--- a/tests/read_repair_test.rs
+++ b/tests/read_repair_test.rs
@@ -6,6 +6,7 @@ use cass::rpc::{QueryRequest, cass_client::CassClient, query_response};
 mod common;
 use common::CassProcess;
 
+/// A read triggers repair of replicas with stale data.
 #[tokio::test]
 async fn read_repairs_stale_replicas() {
     let base1 = "http://127.0.0.1:18121";

--- a/tests/read_repair_test.rs
+++ b/tests/read_repair_test.rs
@@ -1,0 +1,85 @@
+use std::time::Duration;
+use tokio::time::sleep;
+
+use cass::rpc::{QueryRequest, cass_client::CassClient, query_response};
+
+mod common;
+use common::CassProcess;
+
+#[tokio::test]
+async fn read_repairs_stale_replicas() {
+    let base1 = "http://127.0.0.1:18121";
+    let base2 = "http://127.0.0.1:18122";
+    let dir1 = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+
+    let _child1 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir1.path().to_str().unwrap(),
+        "--node-addr",
+        base1,
+        "--peer",
+        base2,
+        "--rf",
+        "2",
+    ]);
+    let _child2 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir2.path().to_str().unwrap(),
+        "--node-addr",
+        base2,
+        "--peer",
+        base1,
+        "--rf",
+        "2",
+    ]);
+
+    for _ in 0..20 {
+        let ok1 = CassClient::connect(base1.to_string()).await.is_ok();
+        let ok2 = CassClient::connect(base2.to_string()).await.is_ok();
+        if ok1 && ok2 {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    let mut c1 = CassClient::connect(base1.to_string()).await.unwrap();
+    let mut c2 = CassClient::connect(base2.to_string()).await.unwrap();
+    c1.query(QueryRequest {
+        sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+    })
+    .await
+    .unwrap();
+
+    c1.internal(QueryRequest {
+        sql: "--ts:2\nINSERT INTO kv (id, val) VALUES ('r','new')".into(),
+    })
+    .await
+    .unwrap();
+    c2.internal(QueryRequest {
+        sql: "--ts:1\nINSERT INTO kv (id, val) VALUES ('r','old')".into(),
+    })
+    .await
+    .unwrap();
+
+    c1.query(QueryRequest {
+        sql: "SELECT val FROM kv WHERE id = 'r'".into(),
+    })
+    .await
+    .unwrap();
+
+    let resp = c2
+        .query(QueryRequest {
+            sql: "SELECT val FROM kv WHERE id = 'r'".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    if let Some(query_response::Payload::Rows(rs)) = resp.payload {
+        assert_eq!(rs.rows[0].columns.get("val"), Some(&"new".to_string()));
+    } else {
+        panic!("unexpected response");
+    }
+}


### PR DESCRIPTION
## Summary
- support configurable read replica requirement (`--read-consistency`)
- implement hinted handoff and read repair for coordinating replicas
- test hinted handoff, read repair, and read consistency option

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a525b040832481c67581855541df