### PR TITLE
Add AWS EKS Terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
 `AWS_REGION` controls the region (default `us-east-1`).
 
 
+## AWS Deployment with Terraform
+
+A reusable Terraform module for deploying `cass` to an Amazon EKS cluster with
+S3 storage is available under `terraform/modules/cass-eks`. The module provisions
+an EKS cluster, an S3 bucket, and a Kubernetes deployment configured to use S3 as
+the storage backend. See the module's README for usage instructions.
+
+
 ## Example / Docker Compose Cluster
 
 With the server running you can insert and query data using gRPC. The provided `docker-compose.yml` starts a five-node cluster using local

--- a/terraform/modules/cass-eks/README.md
+++ b/terraform/modules/cass-eks/README.md
@@ -1,0 +1,19 @@
+# cass-eks Terraform Module
+
+This module deploys the `cass` database to an AWS Elastic Kubernetes Service (EKS) cluster and configures S3 for storage.
+
+## Usage
+
+```hcl
+module "cass" {
+  source = "./modules/cass-eks"
+
+  region            = "us-east-1"
+  cluster_name      = "cass-cluster"
+  vpc_id            = "vpc-123456"
+  subnet_ids        = ["subnet-1", "subnet-2"]
+  s3_bucket_name    = "my-cass-data"
+}
+```
+
+The module creates an S3 bucket for durable storage and deploys a Kubernetes `Deployment` of the `cass` container within the EKS cluster. Set `cass_image` to use a custom container image.

--- a/terraform/modules/cass-eks/main.tf
+++ b/terraform/modules/cass-eks/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = ">= 20.0"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+  vpc_id          = var.vpc_id
+  subnets         = var.subnet_ids
+
+  eks_managed_node_groups = {
+    default = {
+      min_size       = var.node_min_size
+      max_size       = var.node_max_size
+      desired_size   = var.node_desired_size
+      instance_types = [var.node_instance_type]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket        = var.s3_bucket_name
+  force_destroy = var.s3_force_destroy
+}
+
+data "aws_eks_cluster" "this" {
+  name = module.eks.cluster_name
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+resource "kubernetes_namespace" "cass" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "kubernetes_deployment" "cass" {
+  metadata {
+    name      = "cass"
+    namespace = kubernetes_namespace.cass.metadata[0].name
+    labels = {
+      app = "cass"
+    }
+  }
+
+  spec {
+    replicas = var.cass_replicas
+
+    selector {
+      match_labels = {
+        app = "cass"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "cass"
+        }
+      }
+
+      spec {
+        container {
+          name  = "cass"
+          image = var.cass_image
+
+          env {
+            name  = "CASS_STORAGE"
+            value = "s3"
+          }
+
+          env {
+            name  = "CASS_S3_BUCKET"
+            value = aws_s3_bucket.data.bucket
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/cass-eks/outputs.tf
+++ b/terraform/modules/cass-eks/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_name" {
+  description = "Name of the EKS cluster"
+  value       = module.eks.cluster_name
+}
+
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.data.bucket
+}

--- a/terraform/modules/cass-eks/variables.tf
+++ b/terraform/modules/cass-eks/variables.tf
@@ -1,0 +1,78 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version for the EKS cluster"
+  type        = string
+  default     = "1.29"
+}
+
+variable "vpc_id" {
+  description = "VPC ID for the EKS cluster"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for worker nodes"
+  type        = list(string)
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for worker nodes"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "node_min_size" {
+  description = "Minimum number of worker nodes"
+  type        = number
+  default     = 1
+}
+
+variable "node_max_size" {
+  description = "Maximum number of worker nodes"
+  type        = number
+  default     = 3
+}
+
+variable "node_desired_size" {
+  description = "Desired number of worker nodes"
+  type        = number
+  default     = 1
+}
+
+variable "cass_image" {
+  description = "Container image for cass"
+  type        = string
+  default     = "ghcr.io/example/cass:latest"
+}
+
+variable "cass_replicas" {
+  description = "Number of cass replicas"
+  type        = number
+  default     = 1
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for cass"
+  type        = string
+  default     = "cass"
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket for cass storage"
+  type        = string
+}
+
+variable "s3_force_destroy" {
+  description = "Force destroy S3 bucket even if not empty"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- add Terraform module to deploy cass on AWS EKS using S3 storage
- document Terraform deployment option

## Testing
- `cargo test`
- `terraform -chdir=terraform/modules/cass-eks init -backend=false` (fails: Error accessing remote module registry)

------
https://chatgpt.com/codex/tasks/task_e_68b676f1dc6483249dc3e91c052b6ce6