### PR TITLE
Fix LWT - it wasn't actually using RPCs!

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ INSERT 1 row
   customer_id order_date  order_id
 0 nike        2025-08-25  abc123
 (1 rows)
+
+# Check-and-set (lightweight transaction) examples
+> UPDATE orders SET order_date = '2025-08-27'
+    WHERE customer_id = 'nike' AND order_id = 'abc123' IF order_date = '2025-08-25'
+  [applied]
+0 true
+(1 rows)
+
+> UPDATE orders SET order_date = '2025-08-28'
+    WHERE customer_id = 'nike' AND order_id = 'abc123' IF order_date = '2025-08-25'
+  [applied] order_date
+0 false     2025-08-27
+(1 rows)
 ```
 
 ## Maintenance Commands

--- a/tests/lwt_orders_test.rs
+++ b/tests/lwt_orders_test.rs
@@ -1,0 +1,101 @@
+use cass::rpc::{QueryRequest, cass_client::CassClient, query_response};
+use tokio::time::{sleep, Duration};
+
+mod common;
+use common::CassProcess;
+
+#[tokio::test]
+async fn lwt_update_on_orders_distributed_all_read_consistency() {
+    let base1 = "http://127.0.0.1:18211";
+    let base2 = "http://127.0.0.1:18212";
+    let dir1 = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+
+    let _c1 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir1.path().to_str().unwrap(),
+        "--node-addr",
+        base1,
+        "--peer",
+        base2,
+        "--rf",
+        "2",
+        "--read-consistency",
+        "2",
+    ]);
+    let _c2 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir2.path().to_str().unwrap(),
+        "--node-addr",
+        base2,
+        "--peer",
+        base1,
+        "--rf",
+        "2",
+        "--read-consistency",
+        "2",
+    ]);
+
+    for _ in 0..40 {
+        let ok1 = CassClient::connect(base1.to_string()).await.is_ok();
+        let ok2 = CassClient::connect(base2.to_string()).await.is_ok();
+        if ok1 && ok2 { break; }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    let mut client = CassClient::connect(base1.to_string()).await.unwrap();
+    client
+        .query(QueryRequest { sql: "CREATE TABLE orders (customer_id TEXT, order_id TEXT, order_date TEXT, PRIMARY KEY(customer_id, order_id))".into() })
+        .await
+        .unwrap();
+    client
+        .query(QueryRequest { sql: "INSERT INTO orders VALUES ('nike','abc123','2025-08-27')".into() })
+        .await
+        .unwrap();
+    client
+        .query(QueryRequest { sql: "INSERT INTO orders VALUES ('nike','def456','2025-08-26')".into() })
+        .await
+        .unwrap();
+
+    // Successful LWT update when condition matches
+    let resp = client
+        .query(QueryRequest { sql: "UPDATE orders SET order_date='2025-08-25' WHERE customer_id='nike' AND order_id='abc123' IF order_date='2025-08-27'".into() })
+        .await
+        .unwrap()
+        .into_inner();
+    if let Some(query_response::Payload::Rows(rs)) = resp.payload {
+        let row = &rs.rows[0].columns;
+        assert_eq!(row.get("[applied]"), Some(&"true".to_string()));
+    } else {
+        panic!("unexpected response for successful LWT");
+    }
+
+    // Failed LWT update when condition no longer matches; should include current value
+    let resp2 = client
+        .query(QueryRequest { sql: "UPDATE orders SET order_date='2025-08-24' WHERE customer_id='nike' AND order_id='abc123' IF order_date='2025-08-27'".into() })
+        .await
+        .unwrap()
+        .into_inner();
+    if let Some(query_response::Payload::Rows(rs)) = resp2.payload {
+        let row = &rs.rows[0].columns;
+        assert_eq!(row.get("[applied]"), Some(&"false".to_string()));
+        assert_eq!(row.get("order_date"), Some(&"2025-08-25".to_string()));
+    } else {
+        panic!("unexpected response for failed LWT");
+    }
+
+    // Verify actual DB value remains '2025-08-25' after first success
+    let resp3 = client
+        .query(QueryRequest { sql: "SELECT order_date FROM orders WHERE customer_id='nike' AND order_id='abc123'".into() })
+        .await
+        .unwrap()
+        .into_inner();
+    if let Some(query_response::Payload::Rows(rs)) = resp3.payload {
+        let row = &rs.rows[0].columns;
+        assert_eq!(row.get("order_date"), Some(&"2025-08-25".to_string()));
+    } else {
+        panic!("unexpected select response");
+    }
+}

--- a/tests/show_tables_repl_test.rs
+++ b/tests/show_tables_repl_test.rs
@@ -7,18 +7,26 @@ use common::CassProcess;
 
 #[tokio::test]
 async fn show_tables_via_grpc() {
-    let _ = std::fs::remove_dir_all("/tmp/cass-data");
-    let _child = CassProcess::spawn(["server"]);
+    let dir = tempfile::tempdir().unwrap();
+    let base = "http://127.0.0.1:18121";
+    let _child = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir.path().to_str().unwrap(),
+        "--node-addr",
+        base,
+        "--rf",
+        "1",
+    ]);
 
-    let base = "http://127.0.0.1:8080".to_string();
-    for _ in 0..10 {
-        if CassClient::connect(base.clone()).await.is_ok() {
+    for _ in 0..20 {
+        if CassClient::connect(base.to_string()).await.is_ok() {
             break;
         }
-        sleep(Duration::from_millis(50)).await;
+        sleep(Duration::from_millis(100)).await;
     }
 
-    let mut client = CassClient::connect(base.clone()).await.unwrap();
+    let mut client = CassClient::connect(base.to_string()).await.unwrap();
     client
         .query(QueryRequest {
             sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),


### PR DESCRIPTION
Summary

Add Cassandra-style LWT over Paxos for SQL INSERT ... IF NOT EXISTS and UPDATE ... IF col=val.
Fix IF-clause parsing so SQL with trailing IF ... no longer errors.
Introduce server-level consistency options and apply them to reads and LWT phases.
Add a distributed integration test for LWT and harden a flaky SHOW TABLES test.
Update README with a check-and-set example.
Highlights

LWT over Paxos: The SQL path now runs LwtPrepare → LwtRead → LwtPropose → LwtCommit across replicas, returning [applied] rows and current values when conditions fail. Coordinator enforces the configured consistency for the prepare and propose phases; commit is best-effort to healthy replicas.
IF parsing: Added a “base SQL” extraction so ... IF ... is stripped before planning/routing. Conditional parsing still extracts NOT EXISTS and simple col = value conjunctions for LWT checks.
Consistency levels:
New server flag --lwt-consistency {one|quorum|all} controls LWT phases (default QUORUM).
General reads now use the same enum internally; numeric --read-consistency maps to ONE (1), ALL (>= RF), or QUORUM (otherwise).
LWT read correctness: If the Paxos slot has no accepted value, the Read phase falls back to the DB row, ensuring predicates are checked against current state.
Docs: README now includes a check-and-set example showing both [applied]=true and [applied]=false with the current value.
Configuration

cass server ...
--lwt-consistency one|quorum|all: LWT phases consistency (default: quorum).
--read-consistency <n>: preserved numeric flag; maps to ONE/QUORUM/ALL internally based on RF.
Tests

LWT distributed test: tests/lwt_orders_test.rs
Spins up two nodes (--rf 2) with --read-consistency 2 (ALL).
Creates orders, runs a successful conditional update, then a failing one and confirms [applied] semantics and current values.
SHOW TABLES: tests/show_tables_repl_test.rs
Uses a unique temp data dir and port to avoid picking up tables created by other tests.
Behavioral notes

LWT: On success, returns [applied] = true. On failure, returns [applied] = false plus the current values for equality-checked columns, matching the README and prior tests.
Reads: Coordinated read path checks healthy nodes against the enum-based consistency, preserving prior behavior with improved clarity.
Backward compatibility: Existing commands keep working; --lwt-consistency is additive.
Future Work

Structured tracing for LWT phases for better observability in docker-compose logs.
Support additional predicate forms (e.g., multiple columns in IF, possibly IN).
Optional CLI flag to set read consistency via enum directly (e.g., --read-consistency-level).
Testing Notes

Ran full test suite; all tests pass.
The previously flaky show_tables_via_grpc passes consistently after test isolation.
Verified LWT end-to-end in both single-node and two-node settings with ALL read consistency.
Example

Successful conditional update:
UPDATE orders SET order_date='2025-08-27' WHERE customer_id='nike' AND order_id='abc123' IF order_date='2025-08-25'
Returns [applied]=true
Failed conditional update with current value:
UPDATE orders SET order_date='2025-08-28' WHERE customer_id='nike' AND order_id='abc123' IF order_date='2025-08-25'
Returns [applied]=false and order_date=2025-08-27