### PR TITLE
test: cover cluster execute edge cases

### DIFF
--- a/tests/cluster_execute_test.rs
+++ b/tests/cluster_execute_test.rs
@@ -1,0 +1,111 @@
+use cass::Database;
+use cass::cluster::Cluster;
+use cass::query::QueryError;
+use cass::rpc::{QueryResponse, query_response};
+use cass::storage::local::LocalStorage;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::tempdir;
+
+async fn build_cluster(peers: Vec<String>, vnodes: usize, rf: usize, self_addr: &str) -> Cluster {
+    let dir = tempdir().unwrap();
+    let storage = Arc::new(LocalStorage::new(dir.path()));
+    let db = Arc::new(Database::new(storage, "wal.log").await.unwrap());
+    Cluster::new(db, self_addr.to_string(), peers, vnodes, rf, rf)
+}
+
+fn first_val(resp: QueryResponse, col: &str) -> Option<String> {
+    match resp.payload {
+        Some(query_response::Payload::Rows(rs)) => {
+            rs.rows.get(0).and_then(|row| row.columns.get(col).cloned())
+        }
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn forwarded_insert_executes() {
+    let addr = "http://127.0.0.1:6000";
+    let cluster = build_cluster(Vec::new(), 1, 1, addr).await;
+    cluster
+        .execute(
+            "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))",
+            false,
+        )
+        .await
+        .unwrap();
+    cluster
+        .execute("--ts:5\nINSERT INTO kv (id, val) VALUES ('a','x')", true)
+        .await
+        .unwrap();
+    let resp = cluster
+        .execute("SELECT val FROM kv WHERE id='a'", false)
+        .await
+        .unwrap();
+    assert_eq!(first_val(resp, "val"), Some("x".to_string()));
+}
+
+#[tokio::test]
+async fn insert_errors_when_no_healthy_replicas() {
+    let addr = "http://127.0.0.1:6001";
+    let cluster = build_cluster(Vec::new(), 1, 1, addr).await;
+    cluster
+        .execute("CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))", false)
+        .await
+        .unwrap();
+    cluster.panic_for(Duration::from_secs(2)).await;
+    let err = cluster
+        .execute("INSERT INTO t (id, val) VALUES ('a','1')", false)
+        .await
+        .unwrap_err();
+    match err {
+        QueryError::Other(msg) => assert_eq!(msg, "no healthy replicas"),
+        _ => panic!("unexpected error"),
+    }
+}
+
+#[tokio::test]
+async fn select_errors_when_all_replicas_unhealthy() {
+    let addr = "http://127.0.0.1:6002";
+    let cluster = build_cluster(Vec::new(), 1, 1, addr).await;
+    cluster
+        .execute(
+            "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))",
+            false,
+        )
+        .await
+        .unwrap();
+    cluster
+        .execute("INSERT INTO kv (id, val) VALUES ('a','v')", false)
+        .await
+        .unwrap();
+    cluster.panic_for(Duration::from_secs(2)).await;
+    let err = cluster
+        .execute("SELECT val FROM kv WHERE id='a'", false)
+        .await
+        .unwrap_err();
+    match err {
+        QueryError::Other(msg) => assert_eq!(msg, "not enough healthy replicas"),
+        _ => panic!("unexpected error"),
+    }
+}
+
+#[tokio::test]
+async fn show_tables_succeeds_with_unhealthy_peer() {
+    let self_addr = "http://127.0.0.1:6004";
+    let peer = "http://127.0.0.1:6005".to_string();
+    let cluster = build_cluster(vec![peer], 1, 2, self_addr).await;
+    cluster
+        .execute(
+            "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))",
+            false,
+        )
+        .await
+        .unwrap();
+    let resp = cluster.execute("SHOW TABLES", false).await.unwrap();
+    if let Some(query_response::Payload::Tables(t)) = resp.payload {
+        assert_eq!(t.tables, vec!["kv".to_string()]);
+    } else {
+        panic!("expected table list");
+    }
+}


### PR DESCRIPTION
## Summary
- add cluster.execute tests for forwarded statements, unhealthy replicas, and broadcast queries

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b93f27e4fc8324a3de6e05e0dc7c8b