### PR TITLE
Complete OpenTelemetry tracing integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+!perf-results
+!tests
+!src
+!Cargo.toml
+!Cargo.lock
+!src
+!README.md
+!Dockerfile
+!.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,14 +220,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -249,6 +275,25 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -375,6 +420,9 @@ dependencies = [
  "memmap2",
  "murmur3",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "plotters",
  "prometheus",
  "prost",
@@ -393,11 +441,12 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tonic",
+ "tonic 0.13.1",
  "tonic-build",
  "tonic_prometheus_layer",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
 ]
@@ -803,7 +852,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1731,7 +1780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1804,6 +1853,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -2065,6 +2120,65 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.14",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.14",
+ "tokio",
+ "tonic 0.13.1",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic 0.13.1",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.14",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "option-ext"
@@ -3676,7 +3790,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.12",
@@ -3699,10 +3813,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.12.3"
+name = "tonic"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum 0.8.4",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3722,7 +3865,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "thiserror 1.0.69",
- "tonic",
+ "tonic 0.12.3",
  "tower 0.5.2",
 ]
 
@@ -3754,11 +3897,15 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.10.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3843,6 +3990,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1"
 murmur3 = "0.5"
 futures = "0.3"
 prost = "0.13"
-tonic = { version = "0.12", features = ["transport"] }
+tonic = { version = "0.13", features = ["transport"] }
 url = "2"
 sysinfo = "0.30"
 hyper = { version = "0.14", features = ["full"] }
@@ -27,6 +27,10 @@ rustyline = "12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tower-http = { version = "0.6", features = ["trace"] }
+opentelemetry = { version = "0.30", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.30", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.30", default-features = false, features = ["trace", "grpc-tonic"] }
+tracing-opentelemetry = "0.31"
 memmap2 = "0.9"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 statrs = "0.16"
@@ -42,7 +46,7 @@ regex = "1"
 plotters = { version = "0.3", default-features = false, features = ["bitmap_backend", "bitmap_encoder"] }
 
 [build-dependencies]
-tonic-build = "0.12"
+tonic-build = "0.13"
 protoc-bin-vendored = "3"
 
 [features]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,6 +156,10 @@ services:
       - "16686:16686"
       - "4317:4317"
       - "4318:4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - JAEGER_QUERY__METRICS_BACKEND=prometheus
+      - JAEGER_QUERY__PROMETHEUS_SERVER_URL=http://prometheus:9090
 
   prometheus:
     image: prom/prometheus:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.8'
 services:
   cass1:
     build: .
+    depends_on:
+      - jaeger
     volumes:
       - /tmp/cass-data1:/data
     command:
@@ -23,9 +25,15 @@ services:
       - "3"
     ports:
       - "8080:8080"
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+      - OTEL_SERVICE_NAME=cass
+      - OTEL_SERVICE_INSTANCE_ID=cass1
 
   cass2:
     build: .
+    depends_on:
+      - jaeger
     volumes:
       - /tmp/cass-data2:/data
     command:
@@ -47,9 +55,15 @@ services:
       - "3"
     ports:
       - "8081:8080"
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+      - OTEL_SERVICE_NAME=cass
+      - OTEL_SERVICE_INSTANCE_ID=cass2
 
   cass3:
     build: .
+    depends_on:
+      - jaeger
     volumes:
       - /tmp/cass-data3:/data
     command:
@@ -71,9 +85,15 @@ services:
       - "3"
     ports:
       - "8082:8080"
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+      - OTEL_SERVICE_NAME=cass
+      - OTEL_SERVICE_INSTANCE_ID=cass3
 
   cass4:
     build: .
+    depends_on:
+      - jaeger
     volumes:
       - /tmp/cass-data4:/data
     command:
@@ -95,9 +115,15 @@ services:
       - "3"
     ports:
       - "8083:8080"
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+      - OTEL_SERVICE_NAME=cass
+      - OTEL_SERVICE_INSTANCE_ID=cass4
 
   cass5:
     build: .
+    depends_on:
+      - jaeger
     volumes:
       - /tmp/cass-data5:/data
     command:
@@ -119,6 +145,17 @@ services:
       - "3"
     ports:
       - "8084:8080"
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+      - OTEL_SERVICE_NAME=cass
+      - OTEL_SERVICE_INSTANCE_ID=cass5
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
 
   prometheus:
     image: prom/prometheus:latest

--- a/examples/perf_client.rs
+++ b/examples/perf_client.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     // Ensure table exists via a single client
     {
-        let mut client = CassClient::connect(args.node.clone()).await?;
+        let mut client = CassClient::connect_traced(args.node.clone()).await?;
         client
             .query(QueryRequest {
                 sql: "CREATE TABLE IF NOT EXISTS perf (k INT PRIMARY KEY, v INT)".into(),
@@ -98,7 +98,7 @@ async fn run_phase(
     let rem = ops % threads;
     let mut handles = Vec::with_capacity(threads);
     // Establish a base client once; clones share the underlying HTTP/2 channel
-    let base_client = std::sync::Arc::new(CassClient::connect(node.clone()).await?);
+    let base_client = std::sync::Arc::new(CassClient::connect_traced(node.clone()).await?);
     for t in 0..threads {
         let base_client = base_client.clone();
         let count = if t < rem { base + 1 } else { base };

--- a/examples/perf_client.rs
+++ b/examples/perf_client.rs
@@ -3,7 +3,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use cass::rpc::{QueryRequest, cass_client::CassClient};
+use cass::{
+    rpc::{QueryRequest, cass_client::CassClient},
+    telemetry::PropagatingInterceptor,
+};
 use clap::Parser;
 use futures::{
     future::try_join_all,
@@ -11,7 +14,9 @@ use futures::{
 };
 use statrs::statistics::Statistics;
 use tokio::{fs, time::timeout};
-use tonic::transport::Channel;
+use tonic::{codegen::InterceptedService, transport::Channel};
+
+type TracedCassClient = CassClient<InterceptedService<Channel, PropagatingInterceptor>>;
 use url::Url;
 
 #[derive(Parser)]
@@ -139,8 +144,8 @@ async fn run_phase(
     let base = ops / workers;
     let rem = ops % workers;
 
-    let clients: Vec<CassClient<Channel>> =
-        try_join_all((0..workers).map(|_| CassClient::connect(node.clone()))).await?;
+    let clients: Vec<TracedCassClient> =
+        try_join_all((0..workers).map(|_| CassClient::connect_traced(node.clone()))).await?;
 
     let mut handles = Vec::with_capacity(workers);
     let concurrency = inflight.max(1);
@@ -187,7 +192,7 @@ enum RequestOutcome {
 }
 
 async fn run_worker(
-    client: CassClient<Channel>,
+    client: TracedCassClient,
     offset: usize,
     count: usize,
     write: bool,
@@ -209,7 +214,7 @@ async fn run_worker(
     let mut timeouts = 0;
     let mut messages = Vec::new();
 
-    let mut pool: VecDeque<CassClient<Channel>> = VecDeque::with_capacity(concurrency);
+    let mut pool: VecDeque<TracedCassClient> = VecDeque::with_capacity(concurrency);
     pool.push_back(client);
     if concurrency > 1 {
         let template = pool.front().expect("client pool").clone();

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,174 @@
+use std::error::Error;
+
+use opentelemetry::{Context, KeyValue, global, trace::TracerProvider};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    error::OTelSdkResult, propagation::TraceContextPropagator, resource::Resource,
+    trace::SdkTracerProvider,
+};
+use tonic::codegen::http::HeaderMap;
+use tonic::{
+    Request, Status,
+    metadata::{Ascii, KeyRef, MetadataKey, MetadataMap, MetadataValue},
+    service::Interceptor,
+};
+use tracing::Span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// RAII guard that shuts down the tracer provider when dropped.
+pub struct TelemetryGuard {
+    provider: Option<SdkTracerProvider>,
+}
+
+impl TelemetryGuard {
+    /// Shutdown the underlying tracer provider, flushing any pending spans.
+    pub fn shutdown(mut self) -> OTelSdkResult {
+        if let Some(provider) = self.provider.take() {
+            provider.shutdown()
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for TelemetryGuard {
+    fn drop(&mut self) {
+        if let Some(provider) = self.provider.take() {
+            if let Err(err) = provider.shutdown() {
+                tracing::error!(?err, "failed to shutdown tracer provider");
+            }
+        }
+    }
+}
+
+/// Initialize the global tracing subscriber with stdout and OTLP exporters.
+///
+/// The OTLP collector endpoint defaults to `http://127.0.0.1:4317` and can be
+/// overridden via the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable.
+/// Similarly the service name can be set with `OTEL_SERVICE_NAME` and the
+/// service instance with `OTEL_SERVICE_INSTANCE_ID`.
+///
+/// Returns a [`TelemetryGuard`] which must remain in scope for as long as
+/// tracing should be active. Dropping the guard will attempt to flush any
+/// buffered spans before shutdown.
+pub fn init_tracing(
+    default_service_name: &str,
+    default_instance: Option<String>,
+) -> Result<TelemetryGuard, Box<dyn Error>> {
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let otlp_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://127.0.0.1:4317".to_string());
+    let service_name =
+        std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| default_service_name.to_string());
+    let instance = std::env::var("OTEL_SERVICE_INSTANCE_ID")
+        .ok()
+        .or(default_instance);
+
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let mut resource_builder = Resource::builder().with_service_name(service_name);
+    if let Some(instance_id) = instance {
+        resource_builder =
+            resource_builder.with_attribute(KeyValue::new("service.instance.id", instance_id));
+    }
+    let resource = resource_builder.build();
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(otlp_endpoint)
+        .build()?;
+
+    let provider = SdkTracerProvider::builder()
+        .with_resource(resource)
+        .with_batch_exporter(exporter)
+        .build();
+
+    let guard = TelemetryGuard {
+        provider: Some(provider.clone()),
+    };
+    let tracer = provider.tracer(default_service_name.to_owned());
+    let _ = global::set_tracer_provider(provider);
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_target(true);
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer)
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .try_init()?;
+
+    Ok(guard)
+}
+
+/// Extract a remote context from HTTP headers (used by gRPC requests).
+pub fn extract_remote_context_from_headers(headers: &HeaderMap) -> Context {
+    global::get_text_map_propagator(|prop| prop.extract(&HeaderExtractor(headers)))
+}
+
+/// Extract a remote context from gRPC metadata.
+pub fn extract_remote_context_from_metadata(metadata: &MetadataMap) -> Context {
+    global::get_text_map_propagator(|prop| prop.extract(&MetadataMapExtractor(metadata)))
+}
+
+/// Inject the current span's context into gRPC metadata.
+pub fn inject_context(metadata: &mut MetadataMap) {
+    global::get_text_map_propagator(|prop| {
+        let context = Span::current().context();
+        prop.inject_context(&context, &mut MetadataMapInjector(metadata));
+    });
+}
+
+/// Interceptor that propagates the current tracing context through outgoing
+/// gRPC metadata.
+#[derive(Clone, Default)]
+pub struct PropagatingInterceptor;
+
+impl Interceptor for PropagatingInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        inject_context(request.metadata_mut());
+        Ok(request)
+    }
+}
+
+struct HeaderExtractor<'a>(&'a HeaderMap);
+
+impl<'a> opentelemetry::propagation::Extractor for HeaderExtractor<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|value| value.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|name| name.as_str()).collect()
+    }
+}
+
+struct MetadataMapExtractor<'a>(&'a MetadataMap);
+
+impl<'a> opentelemetry::propagation::Extractor for MetadataMapExtractor<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|value| value.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0
+            .keys()
+            .filter_map(|key| match key {
+                KeyRef::Ascii(key) => Some(key.as_str()),
+                KeyRef::Binary(_) => None,
+            })
+            .collect()
+    }
+}
+
+struct MetadataMapInjector<'a>(&'a mut MetadataMap);
+
+impl<'a> opentelemetry::propagation::Injector for MetadataMapInjector<'a> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(value) = MetadataValue::<Ascii>::try_from(value.as_str()) {
+            if let Ok(key) = key.parse::<MetadataKey<Ascii>>() {
+                let _ = self.0.insert(key, value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a telemetry module that wires an OTLP tracer provider, installs propagation helpers, and exposes a CassClient interceptor
- update the CLI/server entrypoints to keep the telemetry guard alive, shut it down cleanly, and adapt the gRPC TraceLayer to tonic 0.13 requests
- document how to run Jaeger/OTLP collectors and extend docker-compose with a bundled Jaeger deployment for span inspection

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d0d8e76cdc8324a0475ba46cb4a7f5