### PR TITLE
Read quorum should only repair unhealthy nodes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
       - OTEL_SERVICE_NAME=cass
       - OTEL_SERVICE_INSTANCE_ID=cass1
+      - CASS_DISABLE_TRACING=${CASS_DISABLE_TRACING:-0}
 
   cass2:
     build: .
@@ -59,6 +60,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
       - OTEL_SERVICE_NAME=cass
       - OTEL_SERVICE_INSTANCE_ID=cass2
+      - CASS_DISABLE_TRACING=${CASS_DISABLE_TRACING:-0}
 
   cass3:
     build: .
@@ -89,6 +91,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
       - OTEL_SERVICE_NAME=cass
       - OTEL_SERVICE_INSTANCE_ID=cass3
+      - CASS_DISABLE_TRACING=${CASS_DISABLE_TRACING:-0}
 
   cass4:
     build: .
@@ -119,6 +122,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
       - OTEL_SERVICE_NAME=cass
       - OTEL_SERVICE_INSTANCE_ID=cass4
+      - CASS_DISABLE_TRACING=${CASS_DISABLE_TRACING:-0}
 
   cass5:
     build: .
@@ -149,6 +153,7 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
       - OTEL_SERVICE_NAME=cass
       - OTEL_SERVICE_INSTANCE_ID=cass5
+      - CASS_DISABLE_TRACING=${CASS_DISABLE_TRACING:-0}
 
   jaeger:
     image: jaegertracing/all-in-one:1.54

--- a/scripts/perf_compare.sh
+++ b/scripts/perf_compare.sh
@@ -20,6 +20,9 @@ THREADS_SET=${THREADS_SET:-"1 2 4 8 16 32 64"}
 # If set (or --cass-only flag passed), skip Cassandra phase and only collect cass metrics
 CASS_ONLY=${CASS_ONLY:-0}
 
+# Disable tracing within cass containers for perf runs to avoid export overhead.
+export CASS_DISABLE_TRACING=1
+
 # CLI flag: --cass-only
 for arg in "$@"; do
   case "$arg" in

--- a/tests/read_repair_test.rs
+++ b/tests/read_repair_test.rs
@@ -84,3 +84,79 @@ async fn read_repairs_stale_replicas() {
         panic!("unexpected response");
     }
 }
+
+/// A replica missing a row receives it via read repair on demand.
+#[tokio::test]
+async fn read_repair_populates_missing_replicas() {
+    let base1 = "http://127.0.0.1:18123";
+    let base2 = "http://127.0.0.1:18124";
+    let dir1 = tempfile::tempdir().unwrap();
+    let dir2 = tempfile::tempdir().unwrap();
+
+    let _child1 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir1.path().to_str().unwrap(),
+        "--node-addr",
+        base1,
+        "--peer",
+        base2,
+        "--rf",
+        "2",
+    ]);
+    let _child2 = CassProcess::spawn([
+        "server",
+        "--data-dir",
+        dir2.path().to_str().unwrap(),
+        "--node-addr",
+        base2,
+        "--peer",
+        base1,
+        "--rf",
+        "2",
+    ]);
+
+    for _ in 0..20 {
+        let ok1 = CassClient::connect(base1.to_string()).await.is_ok();
+        let ok2 = CassClient::connect(base2.to_string()).await.is_ok();
+        if ok1 && ok2 {
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    let mut c1 = CassClient::connect(base1.to_string()).await.unwrap();
+    let mut c2 = CassClient::connect(base2.to_string()).await.unwrap();
+    c1.query(QueryRequest {
+        sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+    })
+    .await
+    .unwrap();
+
+    // Write only to node1 so node2 lacks the row.
+    c1.internal(QueryRequest {
+        sql: "--ts:5\nINSERT INTO kv (id, val) VALUES ('missing','present')".into(),
+    })
+    .await
+    .unwrap();
+
+    // Coordinated read should trigger repair for node2.
+    c1.query(QueryRequest {
+        sql: "SELECT val FROM kv WHERE id = 'missing'".into(),
+    })
+    .await
+    .unwrap();
+
+    let resp = c2
+        .query(QueryRequest {
+            sql: "SELECT val FROM kv WHERE id = 'missing'".into(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    if let Some(query_response::Payload::Rows(rs)) = resp.payload {
+        assert_eq!(rs.rows[0].columns.get("val"), Some(&"present".to_string()));
+    } else {
+        panic!("unexpected response");
+    }
+}


### PR DESCRIPTION
For some reason, I was performing read repair on _all_ nodes on every read, rather than just the nodes that _needed_ repair.

From a GPT dialogue:

<html>
<head>

</head>
<body>

<p class="p1">No — read repair is <i>not</i> guaranteed to run on <span class="s1"><b>every</b></span> read at quorum. The behavior is more subtle and depends on consistency level, configuration, and whether discrepancies are detected. Below is a breakdown of how read repair works in Cassandra and when it kicks in.</p>
<p class="p2"><span class="s2"><hr></span></p>
<p class="p2"><span class="s2"><h2><b>What is Read Repair</b></h2></span></p>
<p class="p3"><br></p>
<p class="p1">“Read repair” is Cassandra’s mechanism for fixing inconsistencies among replica nodes during a read. If different replicas have divergent data, the coordinator will repair (update) stale replicas so that all replicas converge over time.<span class="Apple-converted-space">  </span><span class="s3"></span></p>
<p class="p3"><br></p>
<p class="p1">It helps to provide the “monotonic quorum reads” guarantee (i.e. you won’t read a newer value and then later read an older one) under certain settings.<span class="Apple-converted-space">  </span><span class="s3"></span></p>
<p class="p2"><span class="s2"><hr></span></p>
<p class="p2"><span class="s2"><h2><b>When Read Repair Happens (or Doesn’t)</b></h2></span></p>
<p class="p3"><br></p>
<p class="p1">Here are the key conditions and caveats:</p>



Condition | Behavior
-- | --
Consistency Level = ONE (or LOCAL_ONE) | No digest comparison is done, so read repair is not triggered from that read path.
Consistency Level > ONE (e.g. QUORUM, LOCAL_QUORUM, TWO, THREE) | The coordinator will send “digest” requests in addition to full data requests to detect mismatches among replicas. If mismatches are found, a read repair is triggered (for the replicas involved) before returning to the client.
No mismatches detected | If all replicas (or the ones consulted) agree (i.e., digests match), then no repair is needed. The read returns immediately.
Replica not involved in the read | Read repair only affects the replicas that were consulted (touched) during that read, not all replicas in the cluster.
Configuration option: read_repair = NONE | If the table is configured with read_repair = 'NONE', then even if differences are detected, the coordinator will reconcile for answering the read but not necessarily push updates (i.e. “repair”) to the replicas. This trades off monotonic quorum consistency for write atomicity in certain corner cases.
Background / probabilistic read repair (older versions / settings) | Before Cassandra 4.0, there also used to be read_repair_chance and dclocal_read_repair_chance settings to probabilistically trigger read repair even when no read was done, but that behavior has been removed in Cassandra 4.0.




<p class="p1"><span class="s1"><hr></span></p>
<p class="p1"><span class="s1"><h2><b>Summary / Answer to Your Question</b></h2></span></p>
<p class="p1"><span class="s1"><ul><li>
<p class="p1">For a <span class="s1"><b>QUORUM</b></span> read (or any consistency level &gt; ONE), Cassandra <i>may</i> perform a read repair <span class="s1"><b>if</b></span> inconsistencies are detected among the consulted replicas.</p>
</li><li>
<p class="p1">But it does <span class="s1"><b>not</b></span> guarantee that a repair will always run on every read — if all the replica digests match, no repair is needed.</p>
</li><li>
<p class="p1">Also, repair is limited to <i>only the replicas involved in that read</i>, not all replicas in the ring.</p>
</li><li>
<p class="p1">And in Cassandra 4.0 and later, settings (like <span class="s1">read_repair = NONE</span>) can disable repair propagation.</p>
</li></ul></span></p>

</body>
</html>