### PR TITLE
Avoid caching build artifacts on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Cache build artifacts
+        if: github.ref != 'refs/heads/main'
         uses: actions/cache@v4
         with:
           path: target


### PR DESCRIPTION
## Summary
- skip restoring the target cache when running on the main branch to keep coverage builds from exhausting disk space on the runner

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d394620ae4832495ab8a8235bcc65a