### PR TITLE
Send query timestamps via gRPC field

### DIFF
--- a/examples/perf_client.rs
+++ b/examples/perf_client.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         client
             .query(QueryRequest {
                 sql: "CREATE TABLE IF NOT EXISTS perf (k INT PRIMARY KEY, v INT)".into(),
+                ts: 0,
             })
             .await?;
     }
@@ -287,7 +288,7 @@ async fn run_worker(
                 let mut client = client;
                 let op_start = Instant::now();
                 let outcome = if let Some(limit) = deadline {
-                    match timeout(limit, client.query(QueryRequest { sql })).await {
+                    match timeout(limit, client.query(QueryRequest { sql, ts: 0 })).await {
                         Ok(Ok(_)) => RequestOutcome::Ok,
                         Ok(Err(status)) => RequestOutcome::Error {
                             key,
@@ -296,7 +297,7 @@ async fn run_worker(
                         Err(_) => RequestOutcome::Timeout { key },
                     }
                 } else {
-                    match client.query(QueryRequest { sql }).await {
+                    match client.query(QueryRequest { sql, ts: 0 }).await {
                         Ok(_) => RequestOutcome::Ok,
                         Err(status) => RequestOutcome::Error {
                             key,

--- a/proto/cass.proto
+++ b/proto/cass.proto
@@ -18,6 +18,7 @@ service Cass {
 
 message QueryRequest {
   string sql = 1;
+  uint64 ts = 2;
 }
 
 message QueryResponse {

--- a/tests/cluster_lwt_test.rs
+++ b/tests/cluster_lwt_test.rs
@@ -40,6 +40,7 @@ async fn execute_lwt_insert_and_update_paths() {
         .execute(
             "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))",
             false,
+            0,
         )
         .await
         .unwrap();
@@ -48,6 +49,7 @@ async fn execute_lwt_insert_and_update_paths() {
         .execute(
             "INSERT INTO kv (id, val) VALUES ('a','1') IF NOT EXISTS",
             false,
+            0,
         )
         .await
         .unwrap();
@@ -57,19 +59,20 @@ async fn execute_lwt_insert_and_update_paths() {
         .execute(
             "INSERT INTO kv (id, val) VALUES ('a','2') IF NOT EXISTS",
             false,
+            0,
         )
         .await
         .unwrap();
     assert_eq!(applied(&resp), Some("false".to_string()));
 
     let resp = cluster
-        .execute("UPDATE kv SET val='3' WHERE id='a' IF val='1'", false)
+        .execute("UPDATE kv SET val='3' WHERE id='a' IF val='1'", false, 0)
         .await
         .unwrap();
     assert_eq!(applied(&resp), Some("true".to_string()));
 
     let resp = cluster
-        .execute("UPDATE kv SET val='4' WHERE id='a' IF val='1'", false)
+        .execute("UPDATE kv SET val='4' WHERE id='a' IF val='1'", false, 0)
         .await
         .unwrap();
     assert_eq!(applied(&resp), Some("false".to_string()));
@@ -81,7 +84,11 @@ async fn execute_lwt_errors_when_insufficient_replicas() {
     let addr = "http://127.0.0.1:6200";
     let cluster = build_cluster(2, addr).await; // rf=2 but only one node present
     cluster
-        .execute("CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))", false)
+        .execute(
+            "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))",
+            false,
+            0,
+        )
         .await
         .unwrap();
 
@@ -89,6 +96,7 @@ async fn execute_lwt_errors_when_insufficient_replicas() {
         .execute(
             "INSERT INTO t (id, val) VALUES ('a','1') IF NOT EXISTS",
             false,
+            0,
         )
         .await
         .unwrap_err();

--- a/tests/cluster_remote_ops_test.rs
+++ b/tests/cluster_remote_ops_test.rs
@@ -78,7 +78,11 @@ async fn execute_lwt_remote_branches() {
 
     let cluster = build_cluster(vec![remote_addr.clone()], &free_http_addr()).await;
     cluster
-        .execute("CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))", false)
+        .execute(
+            "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))",
+            false,
+            0,
+        )
         .await
         .unwrap();
 
@@ -86,6 +90,7 @@ async fn execute_lwt_remote_branches() {
         .execute(
             "INSERT INTO t (id, val) VALUES ('a','1') IF NOT EXISTS",
             false,
+            0,
         )
         .await
         .unwrap();
@@ -95,6 +100,7 @@ async fn execute_lwt_remote_branches() {
         .execute(
             "INSERT INTO t (id, val) VALUES ('a','2') IF NOT EXISTS",
             false,
+            0,
         )
         .await
         .unwrap();
@@ -104,6 +110,7 @@ async fn execute_lwt_remote_branches() {
     let res = client
         .query(QueryRequest {
             sql: "SELECT val FROM t WHERE id='a'".into(),
+            ts: 0,
         })
         .await
         .unwrap()

--- a/tests/gossip_health_test.rs
+++ b/tests/gossip_health_test.rs
@@ -86,11 +86,13 @@ async fn errors_when_not_enough_healthy_replicas() {
     let mut c1 = CassClient::connect(base1.clone()).await.unwrap();
     c1.query(QueryRequest {
         sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+        ts: 0,
     })
     .await
     .unwrap();
     c1.query(QueryRequest {
         sql: "INSERT INTO kv (id, val) VALUES ('x','1')".into(),
+        ts: 0,
     })
     .await
     .unwrap();
@@ -102,6 +104,7 @@ async fn errors_when_not_enough_healthy_replicas() {
         let res = c1
             .query(QueryRequest {
                 sql: "SELECT val FROM kv WHERE id = 'x'".into(),
+                ts: 0,
             })
             .await;
         if let Err(e) = res {
@@ -170,11 +173,13 @@ async fn read_succeeds_with_lower_consistency() {
     let mut c1 = CassClient::connect(base1.clone()).await.unwrap();
     c1.query(QueryRequest {
         sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+        ts: 0,
     })
     .await
     .unwrap();
     c1.query(QueryRequest {
         sql: "INSERT INTO kv (id, val) VALUES ('a','1')".into(),
+        ts: 0,
     })
     .await
     .unwrap();
@@ -186,6 +191,7 @@ async fn read_succeeds_with_lower_consistency() {
         let res = c1
             .query(QueryRequest {
                 sql: "SELECT val FROM kv WHERE id = 'a'".into(),
+                ts: 0,
             })
             .await;
         if let Ok(resp) = res {

--- a/tests/hinted_handoff_test.rs
+++ b/tests/hinted_handoff_test.rs
@@ -53,6 +53,7 @@ async fn hinted_handoff_replays_when_node_recovers() {
     let mut c1 = CassClient::connect(base1.to_string()).await.unwrap();
     c1.query(QueryRequest {
         sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+        ts: 0,
     })
     .await
     .unwrap();
@@ -61,6 +62,7 @@ async fn hinted_handoff_replays_when_node_recovers() {
 
     c1.query(QueryRequest {
         sql: "INSERT INTO kv (id, val) VALUES ('h','1')".into(),
+        ts: 0,
     })
     .await
     .unwrap();
@@ -91,12 +93,14 @@ async fn hinted_handoff_replays_when_node_recovers() {
         let _ = c1
             .query(QueryRequest {
                 sql: "SELECT val FROM kv WHERE id = 'h'".into(),
+                ts: 0,
             })
             .await;
         let mut c2 = CassClient::connect(base2.to_string()).await.unwrap();
         let resp = c2
             .query(QueryRequest {
                 sql: "SELECT val FROM kv WHERE id = 'h'".into(),
+                ts: 0,
             })
             .await
             .unwrap()

--- a/tests/partition_key_test.rs
+++ b/tests/partition_key_test.rs
@@ -29,21 +29,21 @@ async fn select_requires_partition_key() {
 
     let mut client = CassClient::connect(base.to_string()).await.unwrap();
     client
-        .query(QueryRequest {
-            sql: "CREATE TABLE orders (customer_id TEXT, order_id TEXT, order_date TEXT, PRIMARY KEY(customer_id, \
-                order_id))".into(),
-        })
+        .query(QueryRequest { sql: "CREATE TABLE orders (customer_id TEXT, order_id TEXT, order_date TEXT, PRIMARY KEY(customer_id, \
+                order_id))".into(), ts: 0 })
         .await
         .unwrap();
     client
         .query(QueryRequest {
             sql: "INSERT INTO orders VALUES ('nike','abc123','2025-08-25')".into(),
+            ts: 0,
         })
         .await
         .unwrap();
     client
         .query(QueryRequest {
             sql: "INSERT INTO orders VALUES ('nike','def456','2025-08-26')".into(),
+            ts: 0,
         })
         .await
         .unwrap();
@@ -51,6 +51,7 @@ async fn select_requires_partition_key() {
     let res = client
         .query(QueryRequest {
             sql: "SELECT * FROM orders".into(),
+            ts: 0,
         })
         .await;
     assert!(res.unwrap_err().message().contains("partition key"));
@@ -58,6 +59,7 @@ async fn select_requires_partition_key() {
     let rows = client
         .query(QueryRequest {
             sql: "SELECT * FROM orders WHERE customer_id = 'nike'".into(),
+            ts: 0,
         })
         .await
         .unwrap()
@@ -71,6 +73,7 @@ async fn select_requires_partition_key() {
     let cnt = client
         .query(QueryRequest {
             sql: "SELECT COUNT(*) FROM orders WHERE customer_id = 'nike'".into(),
+            ts: 0,
         })
         .await
         .unwrap()

--- a/tests/query_grpc_test.rs
+++ b/tests/query_grpc_test.rs
@@ -30,6 +30,7 @@ async fn grpc_query_roundtrip() {
     client
         .query(QueryRequest {
             sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+            ts: 0,
         })
         .await
         .unwrap();
@@ -37,6 +38,7 @@ async fn grpc_query_roundtrip() {
     client
         .query(QueryRequest {
             sql: "INSERT INTO kv (id, val) VALUES ('foo','bar')".into(),
+            ts: 0,
         })
         .await
         .unwrap();
@@ -44,6 +46,7 @@ async fn grpc_query_roundtrip() {
     let res = client
         .query(QueryRequest {
             sql: "SELECT val FROM kv WHERE id = 'foo'".into(),
+            ts: 0,
         })
         .await
         .unwrap()
@@ -59,6 +62,7 @@ async fn grpc_query_roundtrip() {
     let count = client
         .query(QueryRequest {
             sql: "SELECT COUNT(*) FROM kv WHERE id = 'foo'".into(),
+            ts: 0,
         })
         .await
         .unwrap()

--- a/tests/replication_grpc_test.rs
+++ b/tests/replication_grpc_test.rs
@@ -51,22 +51,26 @@ async fn union_and_lww_across_replicas() {
 
     c1.query(QueryRequest {
         sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+        ts: 0,
     })
     .await
     .unwrap();
 
     c1.internal(QueryRequest {
-        sql: "--ts:1\nINSERT INTO kv (id, val) VALUES ('a','va1')".into(),
+        sql: "INSERT INTO kv (id, val) VALUES ('a','va1')".into(),
+        ts: 1,
     })
     .await
     .unwrap();
     c2.internal(QueryRequest {
-        sql: "--ts:2\nINSERT INTO kv (id, val) VALUES ('a','va2')".into(),
+        sql: "INSERT INTO kv (id, val) VALUES ('a','va2')".into(),
+        ts: 2,
     })
     .await
     .unwrap();
     c2.internal(QueryRequest {
-        sql: "--ts:3\nINSERT INTO kv (id, val) VALUES ('b','vb')".into(),
+        sql: "INSERT INTO kv (id, val) VALUES ('b','vb')".into(),
+        ts: 3,
     })
     .await
     .unwrap();
@@ -74,6 +78,7 @@ async fn union_and_lww_across_replicas() {
     let res_a = c1
         .query(QueryRequest {
             sql: "SELECT val FROM kv WHERE id = 'a'".into(),
+            ts: 0,
         })
         .await
         .unwrap()
@@ -89,6 +94,7 @@ async fn union_and_lww_across_replicas() {
     let res_b = c1
         .query(QueryRequest {
             sql: "SELECT val FROM kv WHERE id = 'b'".into(),
+            ts: 0,
         })
         .await
         .unwrap()
@@ -103,6 +109,7 @@ async fn union_and_lww_across_replicas() {
     let res_c = c1
         .query(QueryRequest {
             sql: "SELECT val FROM kv WHERE id IN ('a', 'b')".into(),
+            ts: 0,
         })
         .await
         .unwrap()
@@ -117,6 +124,7 @@ async fn union_and_lww_across_replicas() {
     let cnt = c1
         .query(QueryRequest {
             sql: "SELECT COUNT(*) FROM kv WHERE id = 'a'".into(),
+            ts: 0,
         })
         .await
         .unwrap()
@@ -132,6 +140,7 @@ async fn union_and_lww_across_replicas() {
     let ack = c1
         .query(QueryRequest {
             sql: "INSERT INTO kv (id, val) VALUES ('x','1'),('y','2')".into(),
+            ts: 0,
         })
         .await
         .unwrap()

--- a/tests/show_tables_cluster_test.rs
+++ b/tests/show_tables_cluster_test.rs
@@ -50,6 +50,7 @@ async fn show_tables_with_unhealthy_replica() {
 
     c1.query(QueryRequest {
         sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+        ts: 0,
     })
     .await
     .unwrap();
@@ -61,6 +62,7 @@ async fn show_tables_with_unhealthy_replica() {
         let res = c1
             .query(QueryRequest {
                 sql: "SHOW TABLES".into(),
+                ts: 0,
             })
             .await;
         if let Ok(resp) = res {

--- a/tests/show_tables_repl_test.rs
+++ b/tests/show_tables_repl_test.rs
@@ -30,6 +30,7 @@ async fn show_tables_via_grpc() {
     client
         .query(QueryRequest {
             sql: "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))".into(),
+            ts: 0,
         })
         .await
         .unwrap();
@@ -37,6 +38,7 @@ async fn show_tables_via_grpc() {
     let res = client
         .query(QueryRequest {
             sql: "SHOW TABLES".into(),
+            ts: 0,
         })
         .await
         .unwrap()


### PR DESCRIPTION
## Summary
- extend the QueryRequest proto with a timestamp field and plumb it through Cluster::execute and execute_on_node so forwarded writes use the explicit value
- update the gRPC service, perf client, and integration tests to populate QueryRequest.ts instead of embedding --ts headers in SQL strings

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d4d6e0ceec83248d25a612c0cf3c07