### PR TITLE
Fix all clippy lint warnings

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -136,7 +136,7 @@ impl ClientPool {
         let channel = self.channel(dst).await?;
         Ok(CassClient::with_interceptor(
             channel,
-            PropagatingInterceptor::default(),
+            PropagatingInterceptor,
         ))
     }
 }
@@ -152,6 +152,7 @@ pub struct Cluster {
     health: Arc<RwLock<HashMap<String, Instant>>>,
     panic_until: Arc<RwLock<Option<Instant>>>,
     disk_ok: Arc<AtomicBool>,
+    #[allow(clippy::type_complexity)]
     hints: Arc<RwLock<HashMap<String, Vec<(u64, Arc<str>)>>>>,
     lwt: Arc<RwLock<HashMap<String, PaxosSlot>>>,
     client_pool: ClientPool,
@@ -269,8 +270,8 @@ impl Cluster {
             Ok(v) => v == "1" || v.eq_ignore_ascii_case("true"),
             Err(_) => std::env::var("CI").is_ok(),
         };
-        if !skip_disk_health {
-            if let Some(path) = db.storage().local_path().map(|p| p.to_path_buf()) {
+        if !skip_disk_health
+            && let Some(path) = db.storage().local_path().map(|p| p.to_path_buf()) {
                 let disk_health = disk_ok.clone();
                 tokio::spawn(async move {
                     loop {
@@ -280,7 +281,6 @@ impl Cluster {
                     }
                 });
             }
-        }
 
         let read_cl = if read_consistency <= 1 {
             ConsistencyLevel::One
@@ -420,11 +420,10 @@ impl Cluster {
     /// A node is considered unhealthy if it is within a panic window
     /// or if its local storage has less than 5% free space remaining.
     pub async fn self_healthy(&self) -> bool {
-        if let Some(until) = *self.panic_until.read().await {
-            if Instant::now() < until {
+        if let Some(until) = *self.panic_until.read().await
+            && Instant::now() < until {
                 return false;
             }
-        }
         self.disk_ok.load(Ordering::Relaxed)
     }
 
@@ -524,9 +523,9 @@ impl Cluster {
             .cloned()
             .collect();
         let span = Span::current();
-        span.record("replica_count", &field::display(replicas.len()));
-        span.record("healthy_count", &field::display(healthy.len()));
-        span.record("unhealthy_count", &field::display(unhealthy.len()));
+        span.record("replica_count", field::display(replicas.len()));
+        span.record("healthy_count", field::display(healthy.len()));
+        span.record("unhealthy_count", field::display(unhealthy.len()));
         if meta.is_write {
             if healthy.is_empty() {
                 return Err(QueryError::Other("no healthy replicas".into()));
@@ -585,8 +584,8 @@ impl Cluster {
         }
 
         let span = Span::current();
-        span.record("required", &field::display(required));
-        span.record("target_count", &field::display(healthy.len()));
+        span.record("required", field::display(required));
+        span.record("target_count", field::display(healthy.len()));
 
         let mut successes = 0usize;
         let mut results: Vec<Result<QueryOutput, QueryError>> = Vec::new();
@@ -709,19 +708,14 @@ impl Cluster {
                 _ => None,
             };
         }
-        if let Some(stmt) = meta.first_stmt.as_ref() {
-            if let Statement::Query(q) = stmt.as_ref() {
-                if let SetExpr::Select(s) = &*q.body {
-                    if s.projection.len() == 1 {
-                        if let SelectItem::UnnamedExpr(Expr::Function(func)) = &s.projection[0] {
-                            if func.name.to_string().eq_ignore_ascii_case("count") {
+        if let Some(stmt) = meta.first_stmt.as_ref()
+            && let Statement::Query(q) = stmt.as_ref()
+                && let SetExpr::Select(s) = &*q.body
+                    && s.projection.len() == 1
+                        && let SelectItem::UnnamedExpr(Expr::Function(func)) = &s.projection[0]
+                            && func.name.to_string().eq_ignore_ascii_case("count") {
                                 meta.is_count = true;
                             }
-                        }
-                    }
-                }
-            }
-        }
         meta.broadcast = stmts.iter().all(|s| {
             matches!(
                 s.as_ref(),
@@ -746,12 +740,11 @@ impl Cluster {
                     }
             )
         });
-        if parsed.is_lwt() {
-            if let Some(st) = &meta.first_stmt {
+        if parsed.is_lwt()
+            && let Some(st) = &meta.first_stmt {
                 meta.is_lwt =
                     matches!(st.as_ref(), Statement::Insert(_) | Statement::Update { .. });
             }
-        }
         meta
     }
 
@@ -802,8 +795,8 @@ impl Cluster {
         // Determine replicas for the partition
         let replicas = self.target_replicas(engine, parsed, false).await?;
         let healthy = self.healthy_nodes(replicas.clone()).await;
-        Span::current().record("replica_count", &field::display(replicas.len()));
-        Span::current().record("healthy_count", &field::display(healthy.len()));
+        Span::current().record("replica_count", field::display(replicas.len()));
+        Span::current().record("healthy_count", field::display(healthy.len()));
         let rf = self.rf.max(1);
         let required = ConsistencyLevel::Quorum.required(rf);
         if healthy.len() < required {
@@ -851,7 +844,7 @@ impl Cluster {
                 } else {
                     schema.columns.clone()
                 };
-                let row_exprs = values.rows.get(0).ok_or(QueryError::Unsupported)?;
+                let row_exprs = values.rows.first().ok_or(QueryError::Unsupported)?;
                 if cols.len() != row_exprs.len() {
                     return Err(QueryError::Unsupported);
                 }
@@ -906,8 +899,8 @@ impl Cluster {
                         max_accepted_value = acc_v;
                     }
                 }
-            } else if let Ok(mut client) = self.grpc_client(node).await {
-                if let Ok(resp) = client
+            } else if let Ok(mut client) = self.grpc_client(node).await
+                && let Ok(resp) = client
                     .lwt_prepare(tonic::Request::new(LwtPrepareRequest {
                         namespace: ns.clone(),
                         key: key.clone(),
@@ -924,7 +917,6 @@ impl Cluster {
                         }
                     }
                 }
-            }
         }
         if promised < required {
             return Err(QueryError::Other("not enough healthy replicas".into()));
@@ -942,8 +934,8 @@ impl Cluster {
                     read_ballot = b;
                     read_value = v;
                 }
-            } else if let Ok(mut client) = self.grpc_client(node).await {
-                if let Ok(resp) = client
+            } else if let Ok(mut client) = self.grpc_client(node).await
+                && let Ok(resp) = client
                     .lwt_read(tonic::Request::new(LwtReadRequest {
                         namespace: ns.clone(),
                         key: key.clone(),
@@ -961,7 +953,6 @@ impl Cluster {
                         read_value = r.value;
                     }
                 }
-            }
         }
 
         // Evaluate condition and build proposed value
@@ -995,8 +986,8 @@ impl Cluster {
                         // apply assignments
                         if let Some((schema, assigns)) = assignments {
                             for assign in assigns {
-                                if let AssignmentTarget::ColumnName(name) = &assign.target {
-                                    if let Some(id) = name.0.first().and_then(|p| p.as_ident()) {
+                                if let AssignmentTarget::ColumnName(name) = &assign.target
+                                    && let Some(id) = name.0.first().and_then(|p| p.as_ident()) {
                                         let col = id.value.to_lowercase();
                                         if schema.partition_keys.contains(&col)
                                             || schema.clustering_keys.contains(&col)
@@ -1007,7 +998,6 @@ impl Cluster {
                                             current.insert(col, val);
                                         }
                                     }
-                                }
                             }
                         }
                         let mut buf = ts.to_be_bytes().to_vec();
@@ -1032,8 +1022,8 @@ impl Cluster {
                 {
                     accepted += 1;
                 }
-            } else if let Ok(mut client) = self.grpc_client(node).await {
-                if let Ok(resp) = client
+            } else if let Ok(mut client) = self.grpc_client(node).await
+                && let Ok(resp) = client
                     .lwt_propose(tonic::Request::new(LwtProposeRequest {
                         namespace: ns.clone(),
                         key: key.clone(),
@@ -1041,12 +1031,9 @@ impl Cluster {
                         value: proposed_value.clone(),
                     }))
                     .await
-                {
-                    if resp.into_inner().accepted {
+                    && resp.into_inner().accepted {
                         accepted += 1;
                     }
-                }
-            }
         }
         if accepted < required {
             return Err(QueryError::Other("not enough healthy replicas".into()));
@@ -1098,20 +1085,15 @@ impl Cluster {
 
     fn where_to_map(expr: &Expr) -> BTreeMap<String, String> {
         fn collect(e: &Expr, out: &mut BTreeMap<String, String>) {
-            match e {
-                Expr::BinaryOp { left, op, right } => {
-                    if *op == sqlparser::ast::BinaryOperator::And {
-                        collect(left, out);
-                        collect(right, out);
-                    } else if *op == sqlparser::ast::BinaryOperator::Eq {
-                        if let Expr::Identifier(id) = &**left {
-                            if let Some(val) = Cluster::expr_to_string(right) {
-                                out.insert(id.value.to_lowercase(), val);
-                            }
+            if let Expr::BinaryOp { left, op, right } = e {
+                if *op == sqlparser::ast::BinaryOperator::And {
+                    collect(left, out);
+                    collect(right, out);
+                } else if *op == sqlparser::ast::BinaryOperator::Eq
+                    && let Expr::Identifier(id) = &**left
+                        && let Some(val) = Cluster::expr_to_string(right) {
+                            out.insert(id.value.to_lowercase(), val);
                         }
-                    }
-                }
-                _ => {}
             }
         }
         let mut map = BTreeMap::new();
@@ -1174,7 +1156,7 @@ impl Cluster {
         ts: u64,
     ) -> Vec<(String, Result<QueryOutput, QueryError>)> {
         let span = Span::current();
-        span.record("node_count", &field::display(nodes.len()));
+        span.record("node_count", field::display(nodes.len()));
         let parent_span = span.clone();
         let forwarded = Self::forwarded_payload(&sql, ts);
         let tasks: Vec<_> = nodes
@@ -1196,6 +1178,8 @@ impl Cluster {
         join_all(tasks).await
     }
 
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
     #[instrument(
         skip(self, nodes, sql, meta, replicas, unhealthy),
         fields(ts = ts, required = required, node_count = field::Empty)
@@ -1215,7 +1199,7 @@ impl Cluster {
             return Ok(Vec::new());
         }
 
-        Span::current().record("node_count", &field::display(total));
+        Span::current().record("node_count", field::display(total));
 
         let meta_results = Arc::new(Mutex::new(
             Vec::<(String, Vec<(String, u64, String)>)>::new(),
@@ -1378,11 +1362,10 @@ impl Cluster {
             map.get(&composite)
                 .map(|s| (s.accepted_ballot, s.accepted_value.clone()))
         };
-        if let Some((ballot, val)) = maybe {
-            if ballot > 0 && !val.is_empty() {
+        if let Some((ballot, val)) = maybe
+            && ballot > 0 && !val.is_empty() {
                 return (ballot, val);
             }
-        }
         let val = self.db.get_ns(ns, key).await.unwrap_or_default();
         (0, val)
     }
@@ -1423,6 +1406,7 @@ impl Cluster {
 
     /// Reconcile divergent replicas by sending the freshest values to healthy nodes
     /// and hinting any that are down.
+    #[allow(clippy::type_complexity)]
     async fn read_repair(
         &self,
         meta: &QueryMeta,
@@ -1548,11 +1532,10 @@ impl Cluster {
                 }
                 Ok(QueryOutput::Rows(r)) => {
                     if meta.is_count {
-                        if count_val.is_none() {
-                            if let Some(c) = r.get(0).and_then(|m| m.get("count")) {
+                        if count_val.is_none()
+                            && let Some(c) = r.first().and_then(|m| m.get("count")) {
                                 count_val = c.parse::<u64>().ok();
                             }
-                        }
                     } else {
                         arr_rows.extend(r);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ impl rpc::cass_client::CassClient<tonic::transport::Channel> {
             .await?;
         Ok(rpc::cass_client::CassClient::with_interceptor(
             channel,
-            crate::telemetry::PropagatingInterceptor::default(),
+            crate::telemetry::PropagatingInterceptor,
         ))
     }
 }
@@ -106,7 +106,7 @@ impl Database {
         }
         let files = storage.list("sstable_").await.map_err(|e| match e {
             storage::StorageError::Io(e) => e,
-            _ => std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+            _ => std::io::Error::other(e.to_string()),
         })?;
         let mut pairs = Vec::new();
         let mut next_id = 0usize;
@@ -114,12 +114,11 @@ impl Database {
             if let Some(id_str) = f
                 .strip_prefix("sstable_")
                 .and_then(|s| s.strip_suffix(".tbl"))
-            {
-                if let Ok(id) = id_str.parse::<usize>() {
+                && let Ok(id) = id_str.parse::<usize>() {
                     let table = sstable::SsTable::load(&f, storage.as_ref()).await.map_err(
                         |e| match e {
                             storage::StorageError::Io(e) => e,
-                            _ => std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+                            _ => std::io::Error::other(e.to_string()),
                         },
                     )?;
                     if id >= next_id {
@@ -127,7 +126,6 @@ impl Database {
                     }
                     pairs.push((id, table));
                 }
-            }
         }
         pairs.sort_by_key(|(id, _)| *id);
         let sstables = pairs.into_iter().map(|(_, t)| t).collect();
@@ -301,17 +299,14 @@ impl Database {
         for table in tables.iter() {
             if let Ok(raw) = self.storage.get(&table.path).await {
                 for line in raw.split(|b| *b == b'\n').filter(|l| !l.is_empty()) {
-                    if let Some(pos) = line.iter().position(|b| *b == b'\t') {
-                        if let Ok(key) = std::str::from_utf8(&line[..pos]) {
-                            if let Some(rest) = key.strip_prefix(&prefix) {
-                                if let Ok(val) = base64::engine::general_purpose::STANDARD
+                    if let Some(pos) = line.iter().position(|b| *b == b'\t')
+                        && let Ok(key) = std::str::from_utf8(&line[..pos])
+                            && let Some(rest) = key.strip_prefix(&prefix)
+                                && let Ok(val) = base64::engine::general_purpose::STANDARD
                                     .decode(&line[pos + 1..])
                                 {
                                     map.insert(rest.to_string(), val);
                                 }
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ impl Cass for CassService {
         let req = req.into_inner();
         let sql = req.sql;
         let ts = req.ts;
-        span.record("query.sql", &field::display(&sql));
+        span.record("query.sql", field::display(&sql));
         match self.cluster.execute(&sql, false, ts).await {
             Ok(resp) => Ok(Response::new(resp)),
             Err(e) => Err(Status::invalid_argument(e.to_string())),
@@ -140,7 +140,7 @@ impl Cass for CassService {
         let req = req.into_inner();
         let sql = req.sql;
         let ts = req.ts;
-        span.record("query.sql", &field::display(&sql));
+        span.record("query.sql", field::display(&sql));
         match self.cluster.execute(&sql, true, ts).await {
             Ok(resp) => Ok(Response::new(resp)),
             Err(e) => Err(Status::invalid_argument(e.to_string())),
@@ -207,9 +207,9 @@ impl Cass for CassService {
         let span = Span::current();
         span.set_parent(parent_cx);
         let r = req.into_inner();
-        span.record("namespace", &field::display(&r.namespace));
-        span.record("key", &field::display(&r.key));
-        span.record("ballot", &field::display(r.ballot));
+        span.record("namespace", field::display(&r.namespace));
+        span.record("key", field::display(&r.key));
+        span.record("ballot", field::display(r.ballot));
         let (promised, ballot, value) = self
             .cluster
             .lwt_prepare(&r.namespace, &r.key, r.ballot)
@@ -233,9 +233,9 @@ impl Cass for CassService {
         let span = Span::current();
         span.set_parent(parent_cx);
         let r = req.into_inner();
-        span.record("namespace", &field::display(&r.namespace));
-        span.record("key", &field::display(&r.key));
-        span.record("ballot", &field::display(r.ballot));
+        span.record("namespace", field::display(&r.namespace));
+        span.record("key", field::display(&r.key));
+        span.record("ballot", field::display(r.ballot));
         let accepted = self
             .cluster
             .lwt_propose(&r.namespace, &r.key, r.ballot, r.value)
@@ -255,8 +255,8 @@ impl Cass for CassService {
         let span = Span::current();
         span.set_parent(parent_cx);
         let r = req.into_inner();
-        span.record("namespace", &field::display(&r.namespace));
-        span.record("key", &field::display(&r.key));
+        span.record("namespace", field::display(&r.namespace));
+        span.record("key", field::display(&r.key));
         let (ballot, value) = self.cluster.lwt_read(&r.namespace, &r.key).await;
         Ok(Response::new(LwtReadResponse { ballot, value }))
     }
@@ -273,8 +273,8 @@ impl Cass for CassService {
         let span = Span::current();
         span.set_parent(parent_cx);
         let r = req.into_inner();
-        span.record("namespace", &field::display(&r.namespace));
-        span.record("key", &field::display(&r.key));
+        span.record("namespace", field::display(&r.namespace));
+        span.record("key", field::display(&r.key));
         self.cluster.lwt_commit(&r.namespace, &r.key, r.value).await;
         Ok(Response::new(LwtCommitResponse {}))
     }
@@ -511,7 +511,7 @@ async fn repl(nodes: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                                 println!("({} tables)", t.tables.len());
                             }
-                            _ => println!(""),
+                            _ => println!(),
                         }
                         last_err = None;
                         break;

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -37,6 +37,12 @@ pub struct MemTable {
     shards: Vec<Shard>,
 }
 
+impl Default for MemTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MemTable {
     /// Create a new, empty [`MemTable`].
     pub fn new() -> Self {
@@ -134,6 +140,10 @@ impl MemTable {
             total += shard.data.read().await.map.len();
         }
         total
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.len().await == 0
     }
 
     /// Remove all entries from the table.

--- a/src/query.rs
+++ b/src/query.rs
@@ -118,6 +118,12 @@ pub struct SqlEngine {
     dialect: GenericDialect,
 }
 
+impl Default for SqlEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SqlEngine {
     /// Create a new [`SqlEngine`].
     pub fn new() -> Self {
@@ -221,7 +227,7 @@ impl SqlEngine {
     /// For example, strips the trailing `IF NOT EXISTS` or `IF col='val'` from
     /// INSERT/UPDATE statements so the remaining SQL can be parsed normally for
     /// analysis, routing, and planning.
-    pub fn base_sql<'a>(&self, sql: &'a str) -> String {
+    pub fn base_sql(&self, sql: &str) -> String {
         let trimmed = sql.trim();
         // Only consider stripping a trailing IF clause for statements that
         // actually support LWT (INSERT/UPDATE). This avoids breaking valid
@@ -232,11 +238,10 @@ impl SqlEngine {
             .collect::<String>()
             .to_ascii_lowercase();
         let is_lwt_stmt = lower.starts_with("insert") || lower.starts_with("update");
-        if is_lwt_stmt {
-            if let Some(idx) = self.find_trailing_if_index(sql) {
+        if is_lwt_stmt
+            && let Some(idx) = self.find_trailing_if_index(sql) {
                 return sql[..idx].trim().to_string();
             }
-        }
         trimmed.to_string()
     }
 
@@ -256,16 +261,13 @@ impl SqlEngine {
                 return Some(LwtCondition::NotExists);
             }
             let cond_sql = format!("SELECT * FROM tmp WHERE {}", cond_str);
-            if let Ok(mut stmts) = Parser::parse_sql(&self.dialect, &cond_sql) {
-                if let Some(Statement::Query(q)) = stmts.pop() {
-                    if let SetExpr::Select(select) = *q.body {
-                        if let Some(expr) = select.selection {
+            if let Ok(mut stmts) = Parser::parse_sql(&self.dialect, &cond_sql)
+                && let Some(Statement::Query(q)) = stmts.pop()
+                    && let SetExpr::Select(select) = *q.body
+                        && let Some(expr) = select.selection {
                             let map = where_to_map(&expr);
                             return Some(LwtCondition::Equals(map));
                         }
-                    }
-                }
-            }
         }
         None
     }
@@ -344,7 +346,7 @@ impl SqlEngine {
                 if db.get_ns("_tables", &ns).await.is_some() {
                     return Err(QueryError::Unsupported);
                 }
-                let schema = schema_from_create(&ct).ok_or(QueryError::Unsupported)?;
+                let schema = schema_from_create(ct).ok_or(QueryError::Unsupported)?;
                 save_schema(db, &ns, &schema)
                     .await
                     .map_err(|e| QueryError::Other(e.to_string()))?;
@@ -434,7 +436,7 @@ impl SqlEngine {
             if values.rows.len() != 1 {
                 return Err(QueryError::Unsupported);
             }
-            let row = values.rows.get(0).ok_or(QueryError::Unsupported)?;
+            let row = values.rows.first().ok_or(QueryError::Unsupported)?;
             let (key, data) = build_row(schema_ref, &cols, row).ok_or(QueryError::Unsupported)?;
             let applied = db.insert_ns_if_absent_ts(&ns, key, data, ts).await;
             let mut row = BTreeMap::new();
@@ -510,8 +512,8 @@ impl SqlEngine {
             }
         }
         for assign in assignments {
-            if let AssignmentTarget::ColumnName(name) = &assign.target {
-                if let Some(id) = name.0.first().and_then(|p| p.as_ident()) {
+            if let AssignmentTarget::ColumnName(name) = &assign.target
+                && let Some(id) = name.0.first().and_then(|p| p.as_ident()) {
                     let col = id.value.to_lowercase();
                     if schema_ref.partition_keys.contains(&col)
                         || schema_ref.clustering_keys.contains(&col)
@@ -521,7 +523,6 @@ impl SqlEngine {
                     let val = expr_to_string(&assign.value).ok_or(QueryError::Unsupported)?;
                     row_map.insert(col, val);
                 }
-            }
         }
         let data = encode_row(&row_map);
         db.insert_ns_ts(&ns, key, data, ts)
@@ -603,14 +604,12 @@ impl SqlEngine {
         let schema_ref = schema.as_ref();
 
         // handle COUNT(*) with optional WHERE filtering
-        if select.projection.len() == 1 {
-            if let SelectItem::UnnamedExpr(Expr::Function(func)) = &select.projection[0] {
-                if func.name.to_string().eq_ignore_ascii_case("count") {
+        if select.projection.len() == 1
+            && let SelectItem::UnnamedExpr(Expr::Function(func)) = &select.projection[0]
+                && func.name.to_string().eq_ignore_ascii_case("count") {
                     let selection = select.selection.as_ref();
                     return self.exec_count(db, &ns, schema_ref, selection).await;
                 }
-            }
-        }
 
         self.exec_select_schema(db, &ns, schema_ref, select, meta)
             .await
@@ -642,7 +641,7 @@ impl SqlEngine {
                     }
                     if cond_map
                         .iter()
-                        .all(|(c, v)| row_map.get(c).map_or(false, |val| val == v))
+                        .all(|(c, v)| row_map.get(c) == Some(v))
                     {
                         count = 1;
                     }
@@ -661,7 +660,7 @@ impl SqlEngine {
                 }
                 if cond_map
                     .iter()
-                    .all(|(c, v)| row_map.get(c).map_or(false, |val| val == v))
+                    .all(|(c, v)| row_map.get(c) == Some(v))
                 {
                     count += 1;
                 }
@@ -749,7 +748,7 @@ impl SqlEngine {
                         }
                         if cond_multi
                             .iter()
-                            .all(|(c, v)| row_map.get(c).map_or(false, |val| v.contains(val)))
+                            .all(|(c, v)| row_map.get(c).is_some_and(|val| v.contains(val)))
                         {
                             let sel_map = project_row(&row_map, &cols, wildcard);
                             if meta {
@@ -1004,6 +1003,7 @@ fn expr_to_string(expr: &Expr) -> Option<String> {
 }
 
 /// Parse the projection list of a `SELECT` into column names and optional casts.
+#[allow(clippy::type_complexity)]
 fn parse_projection(
     projection: &[SelectItem],
 ) -> Result<(Vec<(String, Option<DataType>)>, bool), QueryError> {
@@ -1046,11 +1046,10 @@ fn project_row(
     for (col, cast) in cols {
         if let Some(val) = row_map.get(col) {
             let mut v = val.clone();
-            if let Some(dt) = cast {
-                if let Some(cv) = cast_simple(val, dt) {
+            if let Some(dt) = cast
+                && let Some(cv) = cast_simple(val, dt) {
                     v = cv;
                 }
-            }
             sel_map.insert(col.clone(), v);
         }
     }
@@ -1065,13 +1064,11 @@ fn where_to_multi_map(expr: &Expr) -> BTreeMap<String, Vec<String>> {
                 if *op == BinaryOperator::And {
                     collect(left, out);
                     collect(right, out);
-                } else if *op == BinaryOperator::Eq {
-                    if let Expr::Identifier(id) = &**left {
-                        if let Some(val) = expr_to_string(right) {
+                } else if *op == BinaryOperator::Eq
+                    && let Expr::Identifier(id) = &**left
+                        && let Some(val) = expr_to_string(right) {
                             out.entry(id.value.to_lowercase()).or_default().push(val);
                         }
-                    }
-                }
             }
             Expr::InList { expr, list, .. } => {
                 if let Expr::Identifier(id) = &**expr {
@@ -1172,20 +1169,15 @@ fn build_single_key(schema: &TableSchema, map: &BTreeMap<String, String>) -> Opt
 /// Convert a simple WHERE clause into a map of column -> value.
 fn where_to_map(expr: &Expr) -> BTreeMap<String, String> {
     fn collect(e: &Expr, out: &mut BTreeMap<String, String>) {
-        match e {
-            Expr::BinaryOp { left, op, right } => {
-                if *op == BinaryOperator::And {
-                    collect(left, out);
-                    collect(right, out);
-                } else if *op == BinaryOperator::Eq {
-                    if let Expr::Identifier(id) = &**left {
-                        if let Some(val) = expr_to_string(right) {
-                            out.insert(id.value.to_lowercase(), val);
-                        }
+        if let Expr::BinaryOp { left, op, right } = e {
+            if *op == BinaryOperator::And {
+                collect(left, out);
+                collect(right, out);
+            } else if *op == BinaryOperator::Eq
+                && let Expr::Identifier(id) = &**left
+                    && let Some(val) = expr_to_string(right) {
+                        out.insert(id.value.to_lowercase(), val);
                     }
-                }
-            }
-            _ => {}
         }
     }
     let mut map = BTreeMap::new();

--- a/src/sstable.rs
+++ b/src/sstable.rs
@@ -126,8 +126,8 @@ impl SsTable {
     ) -> Result<Self, StorageError> {
         let path = path.into();
         let meta_path = meta_path(&path);
-        if let Ok(bytes) = storage.get(&meta_path).await {
-            if let Ok(meta) = TableMeta::decode(bytes.as_ref()) {
+        if let Ok(bytes) = storage.get(&meta_path).await
+            && let Ok(meta) = TableMeta::decode(bytes.as_ref()) {
                 let bloom = meta
                     .bloom
                     .map(BloomFilter::from_proto)
@@ -141,7 +141,6 @@ impl SsTable {
                     index,
                 });
             }
-        }
         let raw = storage.get(&path).await?;
         let mut bloom = BloomFilter::new(1024);
         let mut zone_map = ZoneMap::default();
@@ -151,7 +150,7 @@ impl SsTable {
         for line in raw.split(|b| *b == NL).filter(|l| !l.is_empty()) {
             if let Some(pos) = line.iter().position(|b| *b == SEP) {
                 let key = std::str::from_utf8(&line[..pos])
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    .map_err(std::io::Error::other)?;
                 bloom.insert(key);
                 zone_map.update(key);
                 if i % INDEX_INTERVAL == 0 {
@@ -191,7 +190,7 @@ impl SsTable {
             if let Some(enc) = Self::scan_from(&mmap[offset as usize..], key) {
                 let val = STANDARD
                     .decode(enc)
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    .map_err(std::io::Error::other)?;
                 return Ok(Some(val));
             }
             return Ok(None);
@@ -201,7 +200,7 @@ impl SsTable {
         if let Some(enc) = Self::scan_from(&raw[offset as usize..], key) {
             let val = STANDARD
                 .decode(enc)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
             return Ok(Some(val));
         }
         Ok(None)
@@ -213,7 +212,7 @@ impl SsTable {
     /// lines must be sorted by key in ascending order. When the target key is
     /// found the encoded value slice (the bytes after the separator) is
     /// returned. If the key is not present `None` is returned.
-
+    ///
     /// Find the starting byte offset for a given key using the sparse index.
     fn seek_offset(&self, key: &str) -> u64 {
         if self.index.is_empty() {
@@ -236,10 +235,7 @@ impl SsTable {
     /// value slice when found.
     fn scan_from<'a>(mut slice: &'a [u8], key: &str) -> Option<&'a [u8]> {
         while !slice.is_empty() {
-            let nl_pos = match slice.iter().position(|b| *b == NL) {
-                Some(p) => p,
-                None => return None,
-            };
+            let nl_pos = slice.iter().position(|b| *b == NL)?;
             let line = &slice[..nl_pos];
             if let Some(pos) = line.iter().position(|b| *b == SEP) {
                 let key_bytes = &line[..pos];

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use s3::Bucket;
 use s3::Region;
 use s3::creds::Credentials;
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 
 pub struct S3Storage {
     bucket: Box<Bucket>,
@@ -12,16 +12,16 @@ pub struct S3Storage {
 impl S3Storage {
     pub async fn new(bucket: &str) -> Result<Self, StorageError> {
         let creds = Credentials::from_env().map_err(|e: s3::creds::error::CredentialsError| {
-            StorageError::Io(Error::new(ErrorKind::Other, e.to_string()))
+            StorageError::Io(Error::other(e.to_string()))
         })?;
         let region = Region::from_env("AWS_REGION", Some("AWS_ENDPOINT")).map_err(
             |e: s3::region::error::RegionError| {
-                StorageError::Io(Error::new(ErrorKind::Other, e.to_string()))
+                StorageError::Io(Error::other(e.to_string()))
             },
         )?;
         let bucket = Bucket::new(bucket, region, creds)
             .map_err(|e: s3::error::S3Error| {
-                StorageError::Io(Error::new(ErrorKind::Other, e.to_string()))
+                StorageError::Io(Error::other(e.to_string()))
             })?
             .with_path_style();
         Ok(Self { bucket })
@@ -34,7 +34,7 @@ impl Storage for S3Storage {
         self.bucket
             .put_object(path, &data)
             .await
-            .map_err(|e| StorageError::Io(Error::new(ErrorKind::Other, e.to_string())))?;
+            .map_err(|e| StorageError::Io(Error::other(e.to_string())))?;
         Ok(())
     }
 
@@ -43,10 +43,9 @@ impl Storage for S3Storage {
             .bucket
             .get_object(path)
             .await
-            .map_err(|e| StorageError::Io(Error::new(ErrorKind::Other, e.to_string())))?;
+            .map_err(|e| StorageError::Io(Error::other(e.to_string())))?;
         if resp.status_code() != 200 {
-            return Err(StorageError::Io(Error::new(
-                ErrorKind::Other,
+            return Err(StorageError::Io(Error::other(
                 format!("status {}", resp.status_code()),
             )));
         }
@@ -65,7 +64,7 @@ impl Storage for S3Storage {
             .bucket
             .list(prefix.to_string(), None)
             .await
-            .map_err(|e| StorageError::Io(Error::new(ErrorKind::Other, e.to_string())))?;
+            .map_err(|e| StorageError::Io(Error::other(e.to_string())))?;
         let mut out = Vec::new();
         for res in results {
             for obj in res.contents {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -34,11 +34,10 @@ impl TelemetryGuard {
 
 impl Drop for TelemetryGuard {
     fn drop(&mut self) {
-        if let Some(provider) = self.provider.take() {
-            if let Err(err) = provider.shutdown() {
+        if let Some(provider) = self.provider.take()
+            && let Err(err) = provider.shutdown() {
                 tracing::error!(?err, "failed to shutdown tracer provider");
             }
-        }
     }
 }
 
@@ -174,11 +173,10 @@ struct MetadataMapInjector<'a>(&'a mut MetadataMap);
 
 impl<'a> opentelemetry::propagation::Injector for MetadataMapInjector<'a> {
     fn set(&mut self, key: &str, value: String) {
-        if let Ok(value) = MetadataValue::<Ascii>::try_from(value.as_str()) {
-            if let Ok(key) = key.parse::<MetadataKey<Ascii>>() {
+        if let Ok(value) = MetadataValue::<Ascii>::try_from(value.as_str())
+            && let Ok(key) = key.parse::<MetadataKey<Ascii>>() {
                 let _ = self.0.insert(key, value);
             }
-        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,11 +54,10 @@ pub fn sstable_disk_usage(dir: &str) -> u64 {
                 let p = entry.path();
                 if p.is_dir() {
                     size += visit(&p);
-                } else if p.extension().and_then(|e| e.to_str()) == Some("tbl") {
-                    if let Ok(meta) = entry.metadata() {
+                } else if p.extension().and_then(|e| e.to_str()) == Some("tbl")
+                    && let Ok(meta) = entry.metadata() {
                         size += meta.len();
                     }
-                }
             }
         }
         size

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -61,11 +61,11 @@ fn parse_entries(data: &[u8]) -> std::io::Result<Vec<(String, Vec<u8>)>> {
         }
         if let Some(pos) = line.iter().position(|b| *b == b'\t') {
             let key = std::str::from_utf8(&line[..pos])
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+                .map_err(std::io::Error::other)?
                 .to_string();
             let val = STANDARD
                 .decode(&line[pos + 1..])
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
             res.push((key, val));
         }
     }
@@ -76,7 +76,7 @@ fn map_err(e: StorageError) -> std::io::Error {
     match e {
         StorageError::Io(e) => e,
         StorageError::Unimplemented => {
-            std::io::Error::new(std::io::ErrorKind::Other, "unimplemented")
+            std::io::Error::other("unimplemented")
         }
     }
 }
@@ -146,11 +146,10 @@ impl Drop for Wal {
 
         inner.notify.notify_waiters();
 
-        if let Some(task) = inner.take_flush_task() {
-            if let Err(err) = task.join() {
+        if let Some(task) = inner.take_flush_task()
+            && let Err(err) = task.join() {
                 eprintln!("wal flush worker panicked: {err:?}");
             }
-        }
 
         let flush_inner = inner.clone();
         if let Err(err) = block_on_future(async move { flush_inner.flush_pending().await }) {

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -90,7 +90,7 @@ async fn flush_all_flushes_memtable() {
     let db = Arc::new(Database::new(storage, "wal.log").await.unwrap());
     let self_addr = "http://127.0.0.1:5000".to_string();
     let cluster = Cluster::new(db.clone(), self_addr, Vec::new(), 1, 1, 1);
-    db.insert("k".into(), b"v".to_vec()).await;
+    db.insert("k".into(), b"v".to_vec()).await.unwrap();
     assert_eq!(db.memtable().len().await, 1);
     cluster.flush_all().await.unwrap();
     assert_eq!(db.memtable().len().await, 0);

--- a/tests/cluster_execute_test.rs
+++ b/tests/cluster_execute_test.rs
@@ -17,7 +17,7 @@ async fn build_cluster(peers: Vec<String>, vnodes: usize, rf: usize, self_addr: 
 fn first_val(resp: QueryResponse, col: &str) -> Option<String> {
     match resp.payload {
         Some(query_response::Payload::Rows(rs)) => {
-            rs.rows.get(0).and_then(|row| row.columns.get(col).cloned())
+            rs.rows.first().and_then(|row| row.columns.get(col).cloned())
         }
         _ => None,
     }

--- a/tests/cluster_lwt_test.rs
+++ b/tests/cluster_lwt_test.rs
@@ -16,8 +16,7 @@ async fn build_cluster(rf: usize, self_addr: &str) -> Cluster {
 fn applied(resp: &QueryResponse) -> Option<String> {
     match &resp.payload {
         Some(query_response::Payload::Rows(rs)) => rs
-            .rows
-            .get(0)
+            .rows.first()
             .and_then(|r| r.columns.get("[applied]").cloned()),
         _ => None,
     }
@@ -26,7 +25,7 @@ fn applied(resp: &QueryResponse) -> Option<String> {
 fn column(resp: &QueryResponse, name: &str) -> Option<String> {
     match &resp.payload {
         Some(query_response::Payload::Rows(rs)) => {
-            rs.rows.get(0).and_then(|r| r.columns.get(name).cloned())
+            rs.rows.first().and_then(|r| r.columns.get(name).cloned())
         }
         _ => None,
     }

--- a/tests/cluster_remote_ops_test.rs
+++ b/tests/cluster_remote_ops_test.rs
@@ -19,8 +19,7 @@ async fn build_cluster(peers: Vec<String>, self_addr: &str) -> Cluster {
 fn applied(resp: &cass::rpc::QueryResponse) -> Option<String> {
     match &resp.payload {
         Some(query_response::Payload::Rows(rs)) => rs
-            .rows
-            .get(0)
+            .rows.first()
             .and_then(|r| r.columns.get("[applied]").cloned()),
         _ => None,
     }

--- a/tests/gossip_health_test.rs
+++ b/tests/gossip_health_test.rs
@@ -194,12 +194,11 @@ async fn read_succeeds_with_lower_consistency() {
                 ts: 0,
             })
             .await;
-        if let Ok(resp) = res {
-            if let Some(cass::rpc::query_response::Payload::Rows(rs)) = resp.into_inner().payload {
+        if let Ok(resp) = res
+            && let Some(cass::rpc::query_response::Payload::Rows(rs)) = resp.into_inner().payload {
                 assert_eq!(rs.rows[0].columns.get("val"), Some(&"1".to_string()));
                 break;
             }
-        }
         if start.elapsed() > Duration::from_secs(2) {
             panic!("read did not succeed in time");
         }

--- a/tests/hinted_handoff_test.rs
+++ b/tests/hinted_handoff_test.rs
@@ -105,11 +105,10 @@ async fn hinted_handoff_replays_when_node_recovers() {
             .await
             .unwrap()
             .into_inner();
-        if let Some(query_response::Payload::Rows(rs)) = resp.payload {
-            if rs.rows.get(0).and_then(|r| r.columns.get("val")) == Some(&"1".to_string()) {
+        if let Some(query_response::Payload::Rows(rs)) = resp.payload
+            && rs.rows.first().and_then(|r| r.columns.get("val")) == Some(&"1".to_string()) {
                 break;
             }
-        }
         if start.elapsed() > Duration::from_secs(4) {
             panic!("hint not delivered");
         }

--- a/tests/lsm_flush_test.rs
+++ b/tests/lsm_flush_test.rs
@@ -10,8 +10,8 @@ async fn flush_and_query_from_sstable() {
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
     let db = Database::new(storage, "wal.log").await.unwrap();
 
-    db.insert("k1".to_string(), b"v1".to_vec()).await;
-    db.insert("k2".to_string(), b"v2".to_vec()).await;
+    db.insert("k1".to_string(), b"v1".to_vec()).await.unwrap();
+    db.insert("k2".to_string(), b"v2".to_vec()).await.unwrap();
     // manually flush current memtable to disk
     db.flush().await.unwrap();
 

--- a/tests/query_grpc_test.rs
+++ b/tests/query_grpc_test.rs
@@ -130,4 +130,5 @@ async fn repl_interaction_executes_queries() {
     assert!(found);
 
     let _ = repl.kill();
+    let _ = repl.wait();
 }

--- a/tests/query_order_test.rs
+++ b/tests/query_order_test.rs
@@ -11,15 +11,15 @@ async fn queries_check_storage_in_reverse_chronological_order() {
     let db = Database::new(storage, "wal.log").await.unwrap();
 
     // Oldest value persisted in first SSTable
-    db.insert("k".to_string(), b"v1".to_vec()).await;
+    db.insert("k".to_string(), b"v1".to_vec()).await.unwrap();
     db.flush().await.unwrap();
 
     // Newer value persisted in second SSTable
-    db.insert("k".to_string(), b"v2".to_vec()).await;
+    db.insert("k".to_string(), b"v2".to_vec()).await.unwrap();
     db.flush().await.unwrap();
 
     // Latest value remains in memtable
-    db.insert("k".to_string(), b"v3".to_vec()).await;
+    db.insert("k".to_string(), b"v3".to_vec()).await.unwrap();
 
     // Memtable should take precedence over SSTables
     let v = db.get("k").await.map(|b| b[8..].to_vec());

--- a/tests/show_tables_repl_test.rs
+++ b/tests/show_tables_repl_test.rs
@@ -25,8 +25,8 @@ async fn show_tables_via_grpc() {
     // first real call if we only probe at the transport level.
     let mut client = 'ready: {
         for _ in 0..50 {
-            if let Ok(mut c) = CassClient::connect(base.to_string()).await {
-                if c.query(QueryRequest {
+            if let Ok(mut c) = CassClient::connect(base.to_string()).await
+                && c.query(QueryRequest {
                     sql: "SHOW TABLES".into(),
                     ts: 0,
                 })
@@ -35,7 +35,6 @@ async fn show_tables_via_grpc() {
                 {
                     break 'ready c;
                 }
-            }
             sleep(Duration::from_millis(100)).await;
         }
         panic!("server did not become ready within 5 s");

--- a/tests/sstable_recovery_test.rs
+++ b/tests/sstable_recovery_test.rs
@@ -12,7 +12,7 @@ async fn reload_existing_sstables_on_restart() {
     {
         let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
         let db = Database::new(storage, wal).await.unwrap();
-        db.insert("k1".to_string(), b"v1".to_vec()).await;
+        db.insert("k1".to_string(), b"v1".to_vec()).await.unwrap();
         db.flush().await.unwrap();
     }
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));

--- a/tests/wal_recovery_test.rs
+++ b/tests/wal_recovery_test.rs
@@ -12,7 +12,7 @@ async fn wal_recovery_after_restart() {
     {
         let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
         let db = Database::new(storage, wal).await.unwrap();
-        db.insert("k1".to_string(), b"v1".to_vec()).await;
+        db.insert("k1".to_string(), b"v1".to_vec()).await.unwrap();
         db.sync_wal().await.unwrap();
     }
     let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));


### PR DESCRIPTION
## Summary

- Handle unused `Result` from `db.insert()` calls in tests with `.unwrap()`
- Remove redundant `&` borrows in `field::display()` calls in `main.rs`; fix `println!("")` → `println!()`
- Auto-fix many style warnings via `cargo clippy --fix`: if-let collapsing, `get_first`, `map_or` simplification, `io::Error::other`, elided lifetimes, needless borrows, etc.
- Add `Default` impls for `MemTable` and `SqlEngine` (delegate to `new()`)
- Add `MemTable::is_empty`
- Fix malformed doc comment block in `sstable.rs` (empty line between `///` sections)
- Suppress `type_complexity` on `hints` field, `run_read_with_quorum`, `read_repair`, and `parse_projection`
- Suppress `too_many_arguments` on `run_read_with_quorum`
- Call `repl.wait()` after `repl.kill()` in `query_grpc_test` to avoid zombie processes

## Test plan

- [ ] `cargo clippy --tests` produces zero warnings
- [x] `cargo test` passes

https://claude.ai/code/session_01376NXRbNz1b9eNR2FV9dgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01376NXRbNz1b9eNR2FV9dgt)_