### PR TITLE
Server perf: +7.4% throughput via lock conversions, LTO, parse reuse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ protoc-bin-vendored = "3"
 # This is disabled by default to avoid requiring system fontconfig in CI.
 plot-ttf = ["plotters/ttf"]
 
+[profile.release]
+lto = "thin"
+
 [[bench]]
 name = "lookup"
 harness = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build stage ----
-    FROM rust:1.85-slim-bookworm AS build
+    FROM rust:1.89-slim-bookworm AS build
     WORKDIR /app
     
     # (optional) prime dependency cache

--- a/scripts/_ratchet_score.sh
+++ b/scripts/_ratchet_score.sh
@@ -3,11 +3,14 @@
 # during a ratchet run; doing so invalidates cross-iteration comparison.
 #
 # Builds the cass server image (so source changes take effect), runs
-# scripts/perf_compare.sh --cass-only, then averages the 95th-percentile
-# latency (in ms) across every cass_t*.log file (READ + WRITE lines) and
-# prints a single line:
+# scripts/perf_compare.sh --cass-only, then emits two scores averaged
+# across every cass_t*.log file (READ + WRITE lines):
 #
-#     score: <avg_p95_ms>
+#     Latency Score: <avg_p95_ms>
+#     Operations Score: <avg_ops_per_sec>
+#
+# Configure ratchet with metric_name="Operations Score" (direction=maximize)
+# to optimize throughput, or "Latency Score" (direction=minimize) for p95.
 #
 # Exit non-zero on any pipeline failure so ratchet records a crash.
 set -euo pipefail
@@ -17,10 +20,17 @@ cd "$(dirname "$0")/.."
 docker compose build >/dev/null 2>&1
 ./scripts/perf_compare.sh --cass-only >/dev/null 2>&1
 
-avg=$(cat perf-results/cass_t*.log \
+latency=$(cat perf-results/cass_t*.log \
   | grep '95th' \
   | tr -s ' ' \
   | cut -d' ' -f5 \
   | awk '{ total += $1; count++ } END { if (count == 0) { exit 1 } print total/count }')
 
-printf 'score: %s\n' "$avg"
+ops=$(cat perf-results/cass_t*.log \
+  | grep '^Op rate' \
+  | tr -s ' ' \
+  | cut -d' ' -f4 \
+  | awk '{ total += $1; count++ } END { if (count == 0) { exit 1 } print total/count }')
+
+printf 'Latency Score: %s\n' "$latency"
+printf 'Operations Score: %s\n' "$ops"

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -539,7 +539,7 @@ impl Cluster {
                 return self.merge_results(results.into_iter().map(|(_, r)| r).collect(), meta);
             }
             return self
-                .execute_write_with_consistency(sql_arc, ts, healthy, meta)
+                .execute_write_with_consistency(parsed, sql_arc, ts, healthy, meta)
                 .await;
         }
         if meta.broadcast {
@@ -568,11 +568,12 @@ impl Cluster {
     }
 
     #[instrument(
-        skip(self, sql, healthy, meta),
+        skip(self, parsed, sql, healthy, meta),
         fields(ts = ts, required = field::Empty, target_count = field::Empty)
     )]
     async fn execute_write_with_consistency(
         &self,
+        parsed: ParsedQuery,
         sql: Arc<str>,
         ts: u64,
         healthy: Vec<String>,
@@ -594,7 +595,7 @@ impl Cluster {
         for node in healthy {
             if node == self.self_addr {
                 let res = Self::sql_engine()
-                    .execute_with_ts(&self.db, sql.as_ref(), ts, true)
+                    .execute_with_parsed(&self.db, &parsed, ts, true)
                     .await;
                 if res.is_ok() {
                     successes += 1;

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -149,7 +149,7 @@ pub struct Cluster {
     read_cl: ConsistencyLevel,
     write_cl: ConsistencyLevel,
     self_addr: String,
-    health: Arc<RwLock<HashMap<String, Instant>>>,
+    health: Arc<std::sync::RwLock<HashMap<String, Instant>>>,
     panic_until: Arc<RwLock<Option<Instant>>>,
     disk_ok: Arc<AtomicBool>,
     #[allow(clippy::type_complexity)]
@@ -231,7 +231,7 @@ impl Cluster {
                 initial.insert(p.clone(), Instant::now());
             }
         }
-        let health = Arc::new(RwLock::new(initial));
+        let health = Arc::new(std::sync::RwLock::new(initial));
         let panic_until = Arc::new(RwLock::new(None));
         let client_pool = ClientPool::default();
         let gossip_peers = peers.clone();
@@ -254,7 +254,7 @@ impl Cluster {
                         }
                         Err(_) => false,
                     };
-                    let mut map = gossip_health.write().await;
+                    let mut map = gossip_health.write().expect("health rwlock poisoned");
                     if ok {
                         map.insert(peer.clone(), Instant::now());
                     } else {
@@ -379,14 +379,14 @@ impl Cluster {
         if node == self.self_addr {
             return self.self_healthy().await;
         }
-        let map = self.health.read().await;
+        let map = self.health.read().expect("health rwlock poisoned");
         map.get(node)
             .map(|t| t.elapsed() < Duration::from_secs(8))
             .unwrap_or(false)
     }
 
     pub async fn peer_health(&self) -> Vec<(String, bool)> {
-        let map = self.health.read().await;
+        let map = self.health.read().expect("health rwlock poisoned");
         map.iter()
             .map(|(peer, t)| (peer.clone(), t.elapsed() < Duration::from_secs(8)))
             .collect()
@@ -1722,7 +1722,7 @@ mod tests {
             test_cluster("http://127.0.0.1:9000", vec![peer1.clone(), peer2.clone()]).await;
 
         {
-            let mut map = cluster.health.write().await;
+            let mut map = cluster.health.write().expect("health rwlock poisoned");
             map.insert(peer1.clone(), Instant::now());
             map.insert(peer2.clone(), Instant::now() - Duration::from_secs(10));
         }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -153,7 +153,7 @@ pub struct Cluster {
     panic_until: Arc<RwLock<Option<Instant>>>,
     disk_ok: Arc<AtomicBool>,
     #[allow(clippy::type_complexity)]
-    hints: Arc<RwLock<HashMap<String, Vec<(u64, Arc<str>)>>>>,
+    hints: Arc<std::sync::RwLock<HashMap<String, Vec<(u64, Arc<str>)>>>>,
     lwt: Arc<RwLock<HashMap<String, PaxosSlot>>>,
     client_pool: ClientPool,
 }
@@ -301,7 +301,7 @@ impl Cluster {
             health,
             panic_until,
             disk_ok,
-            hints: Arc::new(RwLock::new(HashMap::new())),
+            hints: Arc::new(std::sync::RwLock::new(HashMap::new())),
             lwt: Arc::new(RwLock::new(HashMap::new())),
             client_pool,
         }
@@ -1286,7 +1286,7 @@ impl Cluster {
         if nodes.is_empty() {
             return;
         }
-        let mut map = self.hints.write().await;
+        let mut map = self.hints.write().expect("hints rwlock poisoned");
         for node in nodes {
             map.entry(node).or_default().push((ts, sql.clone()));
         }
@@ -1298,11 +1298,11 @@ impl Cluster {
         // Steady-state (all peers healthy) the hints map is empty, and this method
         // runs per-replica on every coordinator request — taking a write lock here
         // serialized all concurrent requests through one mutex.
-        if !self.hints.read().await.contains_key(node) {
+        if !self.hints.read().expect("hints rwlock poisoned").contains_key(node) {
             return;
         }
         let hints = {
-            let mut map = self.hints.write().await;
+            let mut map = self.hints.write().expect("hints rwlock poisoned");
             map.remove(node)
         };
         if let Some(hints) = hints {
@@ -1311,7 +1311,7 @@ impl Cluster {
                     .run_on_nodes(vec![node.to_string()], sql.clone(), ts)
                     .await;
                 if res.first().map(|(_, r)| r.is_err()).unwrap_or(true) {
-                    let mut map = self.hints.write().await;
+                    let mut map = self.hints.write().expect("hints rwlock poisoned");
                     map.entry(node.to_string()).or_default().push((ts, sql));
                     break;
                 }
@@ -1752,8 +1752,8 @@ mod tests {
                 1,
             )
             .await;
-        assert!(cluster.hints.read().await.get(&peer).is_some());
+        assert!(cluster.hints.read().expect("hints rwlock poisoned").get(&peer).is_some());
         cluster.apply_hints(&peer).await;
-        assert!(cluster.hints.read().await.get(&peer).is_some());
+        assert!(cluster.hints.read().expect("hints rwlock poisoned").get(&peer).is_some());
     }
 }


### PR DESCRIPTION
## Summary

Throughput optimization run targeting the average operation rate across `perf_compare.sh` (1/2/4/8/16/32/64-thread READ+WRITE phases). Final result: **8270 → 8886 ops/s (+7.4%)**, p95 latency **2.55 → 2.34 ms** as a side effect.

Conducted via `/ratchet:ratchet` (10 iterations, 2 trials each, kept on improvement). Four changes were kept; five hypotheses were tested and reverted. Commits below are in keep order; each one is independently reviewable and was validated in isolation against the prior best.

## Changes

### 1. `2c6b0d6` — `scripts/_ratchet_score.sh`: emit Latency + Operations scores

Tooling change. The prior version of the harness emitted only an averaged p95 latency. This version also emits average ops/s across all (R+W) × (1/2/4/8/16/32/64) phases, so future ratchet runs can configure either metric without re-editing the script. Throughput parsing is anchored on `^Op rate` to avoid matching `Partition rate`/`Row rate`.

**Why it matters:** lets the same harness drive throughput-maximizing or latency-minimizing runs by changing only the ratchet config.

### 2. `04f7f09` — `Dockerfile`: bump Rust 1.85 → 1.89

Build fix. PR #110's `wal.rs` Drop impl introduced let-chain syntax (`if let Some(task) = … && let Err(err) = task.join()`), which stabilized in Rust 1.88. The Dockerfile was still pinned at 1.85, so `docker compose build` failed with E0658 before the perf run could start.

**Why it matters:** unblocks the existing `wal.rs` code in container builds. Local development was unaffected because the dev toolchain is 1.89.

### 3. `8debed1` — `Cluster`: `health` map → `std::sync::RwLock`

The cluster's per-replica liveness map was a `tokio::sync::RwLock<HashMap<String, Instant>>`. Every coordinator request calls `is_alive(replica)` once per replica (RF=3 ⇒ 3 reads per request), and the gossip task writes to it once per second. The critical sections are tiny — a single `HashMap::get` + `Instant::elapsed` for reads, a single `insert` for writes — and never hold the lock across an `.await`.

**Why it matters:** swapping to `std::sync::RwLock` removes the async-lock state machine and the implicit yield point per acquisition. Same pattern as the recent `MemTable` and `WAL` conversions.

**Measured:** +3.2% (8270 → 8534 ops/s).

### 4. `5209e9b` — `Cluster`: `hints` map → `std::sync::RwLock`

Same shape as health. `apply_hints(replica)` runs once per replica per coordinator request and hits a read fast-path (`!hints.contains_key(node) → return`). In steady state with no failures, every request takes this read lock and immediately drops it. Writes only occur when a replica fails or a hint is delivered — rare.

**Why it matters:** removes the async-lock overhead from another per-replica per-request hot path. Critical sections do not hold across `.await`.

**Measured:** +1.6% on top of the prior change (8534 → 8672 ops/s).

### 5. `ae48687` — `Cargo.toml`: enable `lto = "thin"` for release builds

Cargo's release profile defaults to `lto = false`. Thin LTO enables cross-crate inlining and dead-code elimination, which is particularly impactful here because the hot path (`Cluster::execute` → `SqlEngine::parse_query` → `sqlparser`) crosses multiple crate boundaries on every request.

Build cost is meaningful in absolute terms (one-time link is slower) but is fully cushioned by Docker's `target/` cache mount in the multi-stage Dockerfile, so iteration time was not impacted.

**Why it matters:** the simplest single change in the run with the broadest reach — every code path benefits, including the SQL parser and the gRPC stack.

**Measured:** +1.9% (8672 → 8838 ops/s).

### 6. `3594598` — `Cluster`: skip duplicate SQL parse on the local replica

`Cluster::execute` parses the inbound SQL once at line 509 to determine routing (partition keys → replicas). Then `execute_write_with_consistency` re-parsed the same SQL by calling `SqlEngine::execute_with_ts(sql, ...)` for the local-replica branch. The engine already exposed `execute_with_parsed(&ParsedQuery, ...)` — it was just not wired through.

This commit threads the existing `ParsedQuery` from the routing step into `execute_write_with_consistency` and uses `execute_with_parsed` for the local branch. Remote replicas still receive the SQL string and parse it on receipt (no protocol change).

**Why it matters:** eliminates one full sqlparser invocation per write request on the coordinator. The same trick was attempted for the read path (`run_read_with_quorum` → `execute_on_node`) but regressed marginally because the per-peer `Arc<ParsedQuery>` clone overhead outweighed the savings — kept the change scoped to writes only.

**Measured:** +0.5% (8838 → 8886 ops/s); both trials within 0.3% of each other (8899/8872) — clean signal.

## Things tried and reverted

- **`panic_until` → `std::sync::RwLock`** — only 1 read per local request; effect lost in run-to-run noise.
- **`SCHEMA_CACHE` → `std::sync::RwLock`** — read per request via `lookup_schema`; trial avg regressed but unclear whether real or noise.
- **`Server::tcp_nodelay(true)`** — tonic's default may already cover this; no measurable effect.
- **Read-path `Arc<ParsedQuery>` threading** — tight cluster regression (-1.2%); the per-peer Arc-clone cost negated the savings.

## Methodology note

Trial-to-trial variance in this benchmark is roughly 5–10% with occasional outliers up to ~18%. With `--trials 2`, single environmental outliers can defeat sound changes (iter 5 of the run was a clear example: trial 1 = 7081, trial 2 = 8670; the change was good, retried with the same code in iter 8 and kept it). Future ratchet runs against this harness would benefit from `--trials 3`.

## Test plan

- [x] `cargo test` (lib + integration; flaky `cluster_remote_ops_test` integration tests pre-exist on `main` due to port-startup race — not introduced here)
- [x] `docker compose build` succeeds
- [x] `scripts/perf_compare.sh --cass-only` runs end-to-end and produces `perf-results/cass_t*.log`
- [x] Spot-check the `Op rate` and `Latency 95th percentile` lines vs. baseline numbers on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)