### PR TITLE
perf_compare.sh: wait for CQL readiness on each Cassandra node

### DIFF
--- a/scripts/perf_compare.sh
+++ b/scripts/perf_compare.sh
@@ -121,6 +121,8 @@ start_cassandra_cluster() {
       -e HEAP_NEWSIZE=100M \
       cassandra:4.1 >/dev/null
     wait_un_count $n || { docker logs --tail=200 cassA$n || true; return 1; }
+    until docker exec cassA$n cqlsh -e 'DESCRIBE CLUSTER' >/dev/null 2>&1; do
+      echo "waiting for cql on cassA$n..."; sleep 5; done
   done
 }
 

--- a/scripts/perf_compare.sh
+++ b/scripts/perf_compare.sh
@@ -95,6 +95,24 @@ start_cassandra_cluster() {
     done
   }
 
+  # Helper to wait for the CQL native transport to become queryable on a node.
+  # UN (gossip) flips before CQL binds; cassandra-stress drivers will see
+  # "Connection refused" if we proceed without this check.
+  wait_for_cql() {
+    local node=$1
+    local tries=0
+    local max_tries=120  # ~10 minutes
+    until docker exec "$node" cqlsh -e 'DESCRIBE CLUSTER' >/dev/null 2>&1; do
+      tries=$((tries+1))
+      if [ "$tries" -ge "$max_tries" ]; then
+        echo "Timed out waiting for CQL on $node" >&2
+        return 1
+      fi
+      echo "waiting for cql on $node..."
+      sleep 5
+    done
+  }
+
   # Start seed (smaller heap, fewer tokens for quicker startup)
   docker run -d --name cassA1 --hostname cassA1 --network perf-cassandra-net \
     -e CASSANDRA_CLUSTER_NAME=perf \
@@ -107,8 +125,7 @@ start_cassandra_cluster() {
 
   echo "Waiting for seed to be UN and CQL ready..."
   wait_un_count 1 || { docker logs --tail=200 cassA1 || true; return 1; }
-  until docker exec cassA1 cqlsh -e 'DESCRIBE CLUSTER' >/dev/null 2>&1; do
-    echo "waiting for cql on cassA1..."; sleep 5; done
+  wait_for_cql cassA1 || { docker logs --tail=200 cassA1 || true; return 1; }
 
   # Start non-seeds one by one and wait after each
   for n in 2 3 4 5; do
@@ -121,8 +138,7 @@ start_cassandra_cluster() {
       -e HEAP_NEWSIZE=100M \
       cassandra:4.1 >/dev/null
     wait_un_count $n || { docker logs --tail=200 cassA$n || true; return 1; }
-    until docker exec cassA$n cqlsh -e 'DESCRIBE CLUSTER' >/dev/null 2>&1; do
-      echo "waiting for cql on cassA$n..."; sleep 5; done
+    wait_for_cql cassA$n || { docker logs --tail=200 cassA$n || true; return 1; }
   done
 }
 


### PR DESCRIPTION
## Summary

Fix a startup race in `start_cassandra_cluster` where `cassandra-stress` could see `Connection refused: /172.19.0.x:9042` warnings on peer nodes.

## Root cause

The per-node readiness check after `docker run` was only `wait_un_count $n` (gossip view via `nodetool status`). UN ("Up Normal") flips true as soon as a node joins the gossip ring, but the **CQL native transport on port 9042 binds several seconds later**. When `cassandra-stress` connects to the seed and the driver opens connection pools to all peers it learned about via gossip, it races CQL startup on the just-joined peer and emits transport warnings.

The seed (`cassA1`) was already protected by an explicit `cqlsh -e 'DESCRIBE CLUSTER'` poll at line 110. The non-seed loop wasn't.

## Fix

Add the same `cqlsh -e 'DESCRIBE CLUSTER'` poll inside the `for n in 2 3 4 5` loop, after `wait_un_count`. Same pattern as the seed.

## Test plan

- [ ] `scripts/perf_compare.sh` runs end-to-end without `Connection refused` warnings during the Cassandra phase
- [ ] All 5 nodes are CQL-ready before `cassandra-stress` starts
- [ ] `perf-results/cassandra_*_t*.log` files are populated as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)