### PR TITLE
Escape tabs and newlines in keys for the WAL/SSTable line format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,9 @@ impl Database {
     }
 
     async fn insert_internal(&self, key: String, value: Vec<u8>) -> std::io::Result<()> {
-        let mut rec = key.clone().into_bytes();
+        // Escape the key so tabs/newlines in user data cannot break the
+        // line-oriented WAL record format.
+        let mut rec = util::escape_key(&key).into_owned().into_bytes();
         rec.push(b'\t');
         let enc = base64::engine::general_purpose::STANDARD.encode(&value);
         rec.extend_from_slice(enc.as_bytes());
@@ -300,13 +302,15 @@ impl Database {
             if let Ok(raw) = self.storage.get(&table.path).await {
                 for line in raw.split(|b| *b == b'\n').filter(|l| !l.is_empty()) {
                     if let Some(pos) = line.iter().position(|b| *b == b'\t')
-                        && let Ok(key) = std::str::from_utf8(&line[..pos])
-                            && let Some(rest) = key.strip_prefix(&prefix)
+                        && let Ok(escaped) = std::str::from_utf8(&line[..pos]) {
+                            let key = util::unescape_key(escaped);
+                            if let Some(rest) = key.strip_prefix(&prefix)
                                 && let Ok(val) = base64::engine::general_purpose::STANDARD
                                     .decode(&line[pos + 1..])
                                 {
                                     map.insert(rest.to_string(), val);
                                 }
+                        }
                 }
             }
         }

--- a/src/sstable.rs
+++ b/src/sstable.rs
@@ -73,22 +73,29 @@ impl SsTable {
         storage: &S,
     ) -> Result<Self, StorageError> {
         let path = path.into();
-        let mut sorted = entries.to_vec();
+        // Keys are escaped on disk so embedded tabs/newlines cannot break the
+        // line format. The file (and the sparse index) is sorted by the
+        // escaped form, which is also what lookups scan with; the bloom
+        // filter and zone map work on raw keys.
+        let mut sorted: Vec<(String, &String, &Vec<u8>)> = entries
+            .iter()
+            .map(|(k, v)| (crate::util::escape_key(k).into_owned(), k, v))
+            .collect();
         sorted.sort_by(|a, b| a.0.cmp(&b.0));
         let mut bloom = BloomFilter::new(1024);
         let mut zone_map = ZoneMap::default();
         let mut data = Vec::new();
         let mut index = Vec::new();
         let mut offset: u64 = 0;
-        for (i, (k, v)) in sorted.iter().enumerate() {
+        for (i, (ek, k, v)) in sorted.iter().enumerate() {
             if i % INDEX_INTERVAL == 0 {
-                index.push((k.clone(), offset));
+                index.push((ek.clone(), offset));
             }
             // update auxiliary structures
             bloom.insert(k);
             zone_map.update(k);
-            // write "key\tbase64(value)\n" lines
-            data.extend_from_slice(k.as_bytes());
+            // write "escaped_key\tbase64(value)\n" lines
+            data.extend_from_slice(ek.as_bytes());
             data.push(SEP);
             let enc = STANDARD.encode(v);
             data.extend_from_slice(enc.as_bytes());
@@ -149,12 +156,13 @@ impl SsTable {
         let mut i = 0;
         for line in raw.split(|b| *b == NL).filter(|l| !l.is_empty()) {
             if let Some(pos) = line.iter().position(|b| *b == SEP) {
-                let key = std::str::from_utf8(&line[..pos])
+                let escaped = std::str::from_utf8(&line[..pos])
                     .map_err(std::io::Error::other)?;
-                bloom.insert(key);
-                zone_map.update(key);
+                let key = crate::util::unescape_key(escaped);
+                bloom.insert(&key);
+                zone_map.update(&key);
                 if i % INDEX_INTERVAL == 0 {
-                    index.push((key.to_string(), offset));
+                    index.push((escaped.to_string(), offset));
                 }
                 offset += line.len() as u64 + 1; // include newline
                 i += 1;
@@ -181,6 +189,10 @@ impl SsTable {
         if !self.zone_map.contains(key) || !self.bloom.may_contain(key) {
             return Ok(None);
         }
+        // The file and index store escaped keys, so probe with the escaped
+        // form.
+        let escaped = crate::util::escape_key(key);
+        let key = escaped.as_ref();
         let offset = self.seek_offset(key);
         if let Some(root) = storage.local_path() {
             let path = root.join(&self.path);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,54 @@
-use std::{fs, io::Write, path::Path};
+use std::{borrow::Cow, fs, io::Write, path::Path};
 
 use crate::rpc::Row as RpcRow;
+
+/// Escape a key for the line-oriented WAL/SSTable format (`key\tvalue\n`).
+///
+/// Tabs and newlines inside a key would otherwise be indistinguishable from
+/// the field and record delimiters, corrupting every record that follows.
+/// Backslash is escaped as well so decoding is unambiguous.
+pub fn escape_key(key: &str) -> Cow<'_, str> {
+    if !key.bytes().any(|b| matches!(b, b'\\' | b'\t' | b'\n')) {
+        return Cow::Borrowed(key);
+    }
+    let mut out = String::with_capacity(key.len() + 8);
+    for c in key.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\t' => out.push_str("\\t"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(c),
+        }
+    }
+    Cow::Owned(out)
+}
+
+/// Reverse [`escape_key`]. Unknown escape sequences are preserved verbatim
+/// so keys written before escaping existed still parse unchanged.
+pub fn unescape_key(key: &str) -> Cow<'_, str> {
+    if !key.contains('\\') {
+        return Cow::Borrowed(key);
+    }
+    let mut out = String::with_capacity(key.len());
+    let mut chars = key.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('t') => out.push('\t'),
+            Some('n') => out.push('\n'),
+            Some('\\') => out.push('\\'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    Cow::Owned(out)
+}
 
 /// Print rows in a tabular format to the provided writer.
 pub fn print_rows<W: Write>(rows: &[RpcRow], w: &mut W) {
@@ -86,6 +134,36 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
         let expected = "  a\n0 1\n1 2\n(2 rows)\n";
         assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn escape_key_roundtrip() {
+        for key in [
+            "plain",
+            "with\ttab",
+            "with\nnewline",
+            "with\\backslash",
+            "all\t\n\\three\\t\\n",
+            "",
+        ] {
+            let escaped = escape_key(key);
+            assert!(!escaped.contains('\t'));
+            assert!(!escaped.contains('\n'));
+            assert_eq!(unescape_key(&escaped), key);
+        }
+    }
+
+    #[test]
+    fn escape_key_borrows_for_plain_keys() {
+        assert!(matches!(escape_key("plain"), Cow::Borrowed(_)));
+        assert!(matches!(unescape_key("plain"), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn unescape_preserves_unknown_sequences() {
+        // keys written before escaping existed may contain lone backslashes
+        assert_eq!(unescape_key("a\\xb"), "a\\xb");
+        assert_eq!(unescape_key("trailing\\"), "trailing\\");
     }
 
     #[test]

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -62,8 +62,8 @@ fn parse_entries(data: &[u8]) -> std::io::Result<Vec<(String, Vec<u8>)>> {
         }
         if let Some(pos) = line.iter().position(|b| *b == b'\t') {
             let key = std::str::from_utf8(&line[..pos])
-                .map_err(std::io::Error::other)?
-                .to_string();
+                .map_err(std::io::Error::other)?;
+            let key = crate::util::unescape_key(key).into_owned();
             let val = STANDARD
                 .decode(&line[pos + 1..])
                 .map_err(std::io::Error::other)?;

--- a/tests/key_escaping_test.rs
+++ b/tests/key_escaping_test.rs
@@ -1,0 +1,127 @@
+use cass::{
+    Database, SqlEngine,
+    query::QueryOutput,
+    sstable::SsTable,
+    storage::{Storage, local::LocalStorage},
+};
+use std::sync::Arc;
+
+const HOSTILE_KEYS: &[&str] = &[
+    "with\ttab",
+    "with\nnewline",
+    "with\\backslash",
+    "tab\tand\nnewline\\mix",
+];
+
+#[tokio::test]
+async fn wal_recovery_preserves_keys_with_delimiters() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    {
+        let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
+        let db = Database::new(storage, "wal.log").await.unwrap();
+        for (i, key) in HOSTILE_KEYS.iter().enumerate() {
+            db.insert(key.to_string(), format!("v{i}").into_bytes())
+                .await
+                .unwrap();
+        }
+        db.insert("normal".to_string(), b"vn".to_vec()).await.unwrap();
+        db.sync_wal().await.unwrap();
+    }
+    // Reopen: WAL replay must reconstruct the exact keys, and the record
+    // following a hostile key must stay intact.
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(&path));
+    let db = Database::new(storage, "wal.log").await.unwrap();
+    for (i, key) in HOSTILE_KEYS.iter().enumerate() {
+        assert_eq!(
+            db.get(key).await.map(|b| b[8..].to_vec()),
+            Some(format!("v{i}").into_bytes()),
+            "key {key:?} lost or corrupted in WAL recovery"
+        );
+    }
+    assert_eq!(
+        db.get("normal").await.map(|b| b[8..].to_vec()),
+        Some(b"vn".to_vec())
+    );
+    // No phantom rows from mis-split records.
+    assert_eq!(db.scan().await.len(), HOSTILE_KEYS.len() + 1);
+}
+
+#[tokio::test]
+async fn sstable_roundtrip_preserves_keys_with_delimiters() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+    let mut entries: Vec<(String, Vec<u8>)> = HOSTILE_KEYS
+        .iter()
+        .enumerate()
+        .map(|(i, k)| (k.to_string(), format!("v{i}").into_bytes()))
+        .collect();
+    entries.push(("normal".to_string(), b"vn".to_vec()));
+
+    let table = SsTable::create("table", &entries, &storage).await.unwrap();
+    for (k, v) in &entries {
+        assert_eq!(
+            table.get(k, &storage).await.unwrap().as_ref(),
+            Some(v),
+            "key {k:?} not found after SSTable create"
+        );
+    }
+
+    // Rebuild from the raw file (no meta) and via normal load.
+    std::fs::remove_file(dir.path().join("table.meta")).unwrap();
+    let reloaded = SsTable::load("table", &storage).await.unwrap();
+    for (k, v) in &entries {
+        assert_eq!(
+            reloaded.get(k, &storage).await.unwrap().as_ref(),
+            Some(v),
+            "key {k:?} not found after SSTable reload"
+        );
+    }
+}
+
+#[tokio::test]
+async fn flush_and_query_preserve_partition_keys_with_delimiters() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
+    let db = Database::new(storage, "wal.log").await.unwrap();
+    let engine = SqlEngine::new();
+    engine
+        .execute(&db, "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))")
+        .await
+        .unwrap();
+    // A partition key value containing both delimiters.
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('a\tb\nc', 'x')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('plain', 'y')")
+        .await
+        .unwrap();
+    db.flush().await.unwrap();
+
+    let out = engine
+        .execute(&db, "SELECT val FROM t WHERE id = 'a\tb\nc'")
+        .await
+        .unwrap();
+    match out {
+        QueryOutput::Rows(rows) => {
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0]["val"], "x");
+        }
+        _ => panic!("expected rows"),
+    }
+
+    // The neighbouring record must be unaffected.
+    let out = engine
+        .execute(&db, "SELECT val FROM t WHERE id = 'plain'")
+        .await
+        .unwrap();
+    match out {
+        QueryOutput::Rows(rows) => {
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0]["val"], "y");
+        }
+        _ => panic!("expected rows"),
+    }
+}


### PR DESCRIPTION
## Problem

WAL and SSTable records are stored as `key\tbase64(value)\n`. Values are base64-encoded and safe, but keys were written raw — and keys are built from user-supplied partition/clustering values. Inserting a value like `'a\tb'` (or anything containing a newline) split the record at the wrong byte on WAL replay and on every SSTable scan, silently corrupting that record and the parse of everything after it.

## Fix

- New `util::escape_key` / `util::unescape_key` (backslash escaping: `\t`, `\n`, `\\`), `Cow`-based so plain keys don't allocate.
- WAL records escape the key on write (`lib.rs::insert_internal`) and unescape on replay (`wal.rs::parse_entries`).
- SSTables sort, index, and probe by the escaped form so binary search and sorted early-exit scans stay consistent; bloom filters and zone maps keep operating on raw keys. `scan_ns` unescapes parsed keys.

**Compatibility:** keys without special characters are byte-identical to the old format, and unknown escape sequences are preserved verbatim on decode, so existing data files remain readable.

## Tests

- `wal_recovery_preserves_keys_with_delimiters`: hostile keys (tab/newline/backslash mixes) survive restart, neighbouring records intact, no phantom rows.
- `sstable_roundtrip_preserves_keys_with_delimiters`: lookups work after create and after a meta-less rebuild.
- `flush_and_query_preserve_partition_keys_with_delimiters`: end-to-end through the SQL engine with flush.
- Unit tests for escape/unescape round-trips and legacy-sequence tolerance.

Found by codebase audit (high severity: silent data corruption from ordinary inputs).

https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9)_