### PR TITLE
Implement ORDER BY and LIMIT/OFFSET instead of silently ignoring them

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1608,6 +1608,15 @@ impl Cluster {
                     arr_rows.push(map);
                 }
             }
+            // Rows merged from replica meta results have not had ORDER BY or
+            // LIMIT applied yet; do so here on the merged set.
+            if let Some(Statement::Query(q)) = meta.first_stmt.as_deref() {
+                crate::query::apply_order_and_limit(
+                    &mut arr_rows,
+                    q.order_by.as_ref(),
+                    q.limit_clause.as_ref(),
+                )?;
+            }
             return Ok(output_to_proto(QueryOutput::Rows(arr_rows)));
         }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,8 +7,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use sqlparser::ast::{
     Assignment, AssignmentTarget, BinaryOperator, ColumnOption, DataType, Delete, Expr, FromTable,
-    Insert, LimitClause, ObjectName, ObjectType, OrderBy, Query, Select, SelectItem, SetExpr,
-    Statement, TableFactor, TableWithJoins, Value,
+    Insert, LimitClause, ObjectName, ObjectType, OrderBy, OrderByKind, Query, Select, SelectItem,
+    SetExpr, Statement, TableFactor, TableWithJoins, Value,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
@@ -590,8 +590,8 @@ impl SqlEngine {
         &self,
         db: &Database,
         select: &Select,
-        _order: &Option<OrderBy>,
-        _limit: Option<&LimitClause>,
+        order: &Option<OrderBy>,
+        limit: Option<&LimitClause>,
         meta: bool,
     ) -> Result<QueryOutput, QueryError> {
         if select.from.len() != 1 {
@@ -611,8 +611,15 @@ impl SqlEngine {
                     return self.exec_count(db, &ns, schema_ref, selection).await;
                 }
 
-        self.exec_select_schema(db, &ns, schema_ref, select, meta)
-            .await
+        let mut out = self
+            .exec_select_schema(db, &ns, schema_ref, select, meta)
+            .await?;
+        // Meta results are merged across replicas by the cluster layer,
+        // which applies ORDER BY/LIMIT after the merge.
+        if let QueryOutput::Rows(ref mut rows) = out {
+            apply_order_and_limit(rows, order.as_ref(), limit)?;
+        }
+        Ok(out)
     }
 
     /// Execute a `COUNT(*)` query with optional equality filters.
@@ -1121,6 +1128,104 @@ fn build_row(schema: &TableSchema, cols: &[String], row: &[Expr]) -> Option<(Str
         }
     }
     Some((key_parts.join("|"), encode_row(&data_map)))
+}
+
+/// Compare two stored values, numerically when both parse as numbers and
+/// lexicographically otherwise.
+fn cmp_values(a: &str, b: &str) -> std::cmp::Ordering {
+    match (a.parse::<f64>(), b.parse::<f64>()) {
+        (Ok(x), Ok(y)) => x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal),
+        _ => a.cmp(b),
+    }
+}
+
+/// Extract a non-negative integer literal from an expression (e.g. a LIMIT
+/// or OFFSET count).
+fn expr_to_usize(expr: &Expr) -> Result<usize, QueryError> {
+    match expr {
+        Expr::Value(v) => match &v.value {
+            Value::Number(n, _) => n.parse::<usize>().map_err(|_| QueryError::Unsupported),
+            _ => Err(QueryError::Unsupported),
+        },
+        _ => Err(QueryError::Unsupported),
+    }
+}
+
+/// Apply `ORDER BY` and `LIMIT`/`OFFSET` clauses to a result row set.
+///
+/// Clause forms the engine cannot honor return [`QueryError::Unsupported`]
+/// instead of being silently ignored.
+pub fn apply_order_and_limit(
+    rows: &mut Vec<BTreeMap<String, String>>,
+    order: Option<&OrderBy>,
+    limit: Option<&LimitClause>,
+) -> Result<(), QueryError> {
+    if let Some(order) = order {
+        if order.interpolate.is_some() {
+            return Err(QueryError::Unsupported);
+        }
+        let OrderByKind::Expressions(exprs) = &order.kind else {
+            return Err(QueryError::Unsupported);
+        };
+        let mut sort_keys = Vec::new();
+        for e in exprs {
+            if e.with_fill.is_some() {
+                return Err(QueryError::Unsupported);
+            }
+            let Expr::Identifier(id) = &e.expr else {
+                return Err(QueryError::Unsupported);
+            };
+            let asc = e.options.asc.unwrap_or(true);
+            // SQL default: NULLs last when ascending, first when descending.
+            let nulls_first = e.options.nulls_first.unwrap_or(!asc);
+            sort_keys.push((id.value.to_lowercase(), asc, nulls_first));
+        }
+        rows.sort_by(|a, b| {
+            for (col, asc, nulls_first) in &sort_keys {
+                let ord = match (a.get(col), b.get(col)) {
+                    (Some(x), Some(y)) => {
+                        let o = cmp_values(x, y);
+                        if *asc { o } else { o.reverse() }
+                    }
+                    (None, None) => std::cmp::Ordering::Equal,
+                    (None, Some(_)) if *nulls_first => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (Some(_), None) if *nulls_first => std::cmp::Ordering::Greater,
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                };
+                if ord != std::cmp::Ordering::Equal {
+                    return ord;
+                }
+            }
+            std::cmp::Ordering::Equal
+        });
+    }
+    if let Some(clause) = limit {
+        let (limit_expr, offset_expr) = match clause {
+            LimitClause::LimitOffset {
+                limit,
+                offset,
+                limit_by,
+            } => {
+                if !limit_by.is_empty() {
+                    return Err(QueryError::Unsupported);
+                }
+                (limit.as_ref(), offset.as_ref().map(|o| &o.value))
+            }
+            LimitClause::OffsetCommaLimit { offset, limit } => (Some(limit), Some(offset)),
+        };
+        let skip = match offset_expr {
+            Some(e) => expr_to_usize(e)?,
+            None => 0,
+        };
+        if skip > 0 {
+            rows.drain(..skip.min(rows.len()));
+        }
+        if let Some(e) = limit_expr {
+            rows.truncate(expr_to_usize(e)?);
+        }
+    }
+    Ok(())
 }
 
 /// Build partition key strings from column values, generating all combinations.

--- a/tests/query_order_limit_test.rs
+++ b/tests/query_order_limit_test.rs
@@ -1,0 +1,183 @@
+use cass::{
+    Database, SqlEngine,
+    query::{QueryError, QueryOutput},
+    storage::{Storage, local::LocalStorage},
+};
+use std::sync::Arc;
+
+async fn setup_table() -> (Database, SqlEngine) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
+    // keep the tempdir alive for the duration of the test
+    std::mem::forget(dir);
+    let db = Database::new(storage, "wal.log").await.unwrap();
+    let engine = SqlEngine::new();
+    engine
+        .execute(
+            &db,
+            "CREATE TABLE items (pk TEXT, ck TEXT, score TEXT, PRIMARY KEY(pk, ck))",
+        )
+        .await
+        .unwrap();
+    for (ck, score) in [("a", "10"), ("b", "2"), ("c", "30"), ("d", "4")] {
+        engine
+            .execute(
+                &db,
+                &format!("INSERT INTO items (pk, ck, score) VALUES ('p', '{ck}', '{score}')"),
+            )
+            .await
+            .unwrap();
+    }
+    (db, engine)
+}
+
+fn rows(out: QueryOutput) -> Vec<std::collections::BTreeMap<String, String>> {
+    match out {
+        QueryOutput::Rows(rows) => rows,
+        _ => panic!("expected row output"),
+    }
+}
+
+fn column(rows: &[std::collections::BTreeMap<String, String>], col: &str) -> Vec<String> {
+    rows.iter().map(|r| r[col].clone()).collect()
+}
+
+#[tokio::test]
+async fn order_by_ascending_and_descending() {
+    let (db, engine) = setup_table().await;
+    let out = rows(
+        engine
+            .execute(&db, "SELECT * FROM items WHERE pk = 'p' ORDER BY ck ASC")
+            .await
+            .unwrap(),
+    );
+    assert_eq!(column(&out, "ck"), vec!["a", "b", "c", "d"]);
+
+    let out = rows(
+        engine
+            .execute(&db, "SELECT * FROM items WHERE pk = 'p' ORDER BY ck DESC")
+            .await
+            .unwrap(),
+    );
+    assert_eq!(column(&out, "ck"), vec!["d", "c", "b", "a"]);
+}
+
+#[tokio::test]
+async fn order_by_compares_numbers_numerically() {
+    let (db, engine) = setup_table().await;
+    let out = rows(
+        engine
+            .execute(&db, "SELECT * FROM items WHERE pk = 'p' ORDER BY score")
+            .await
+            .unwrap(),
+    );
+    // String comparison would yield 10 < 2 < 30 < 4.
+    assert_eq!(column(&out, "score"), vec!["2", "4", "10", "30"]);
+}
+
+#[tokio::test]
+async fn limit_truncates_results() {
+    let (db, engine) = setup_table().await;
+    let out = rows(
+        engine
+            .execute(
+                &db,
+                "SELECT * FROM items WHERE pk = 'p' ORDER BY ck LIMIT 2",
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(column(&out, "ck"), vec!["a", "b"]);
+
+    let out = rows(
+        engine
+            .execute(
+                &db,
+                "SELECT * FROM items WHERE pk = 'p' ORDER BY ck LIMIT 0",
+            )
+            .await
+            .unwrap(),
+    );
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
+async fn limit_with_offset_pages_results() {
+    let (db, engine) = setup_table().await;
+    let out = rows(
+        engine
+            .execute(
+                &db,
+                "SELECT * FROM items WHERE pk = 'p' ORDER BY ck LIMIT 2 OFFSET 1",
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(column(&out, "ck"), vec!["b", "c"]);
+
+    // Offset past the end yields no rows rather than an error.
+    let out = rows(
+        engine
+            .execute(
+                &db,
+                "SELECT * FROM items WHERE pk = 'p' ORDER BY ck LIMIT 2 OFFSET 100",
+            )
+            .await
+            .unwrap(),
+    );
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
+async fn order_by_multiple_columns() {
+    let (db, engine) = setup_table().await;
+    // Two rows share the same score so the secondary key decides.
+    engine
+        .execute(
+            &db,
+            "INSERT INTO items (pk, ck, score) VALUES ('p', 'e', '2')",
+        )
+        .await
+        .unwrap();
+    let out = rows(
+        engine
+            .execute(
+                &db,
+                "SELECT * FROM items WHERE pk = 'p' ORDER BY score ASC, ck DESC",
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(column(&out, "ck"), vec!["e", "b", "d", "a", "c"]);
+}
+
+#[tokio::test]
+async fn unsupported_order_expression_is_rejected_not_ignored() {
+    let (db, engine) = setup_table().await;
+    // Ordering by an arbitrary expression is not supported; it must surface
+    // as an error rather than returning silently unsorted rows.
+    let res = engine
+        .execute(
+            &db,
+            "SELECT * FROM items WHERE pk = 'p' ORDER BY ck || 'x'",
+        )
+        .await;
+    assert!(matches!(res, Err(QueryError::Unsupported)));
+}
+
+#[tokio::test]
+async fn order_by_missing_column_sorts_nulls_last() {
+    let (db, engine) = setup_table().await;
+    // Row without a score: insert only the key columns.
+    engine
+        .execute(&db, "INSERT INTO items (pk, ck) VALUES ('p', 'z')")
+        .await
+        .unwrap();
+    let out = rows(
+        engine
+            .execute(&db, "SELECT * FROM items WHERE pk = 'p' ORDER BY score")
+            .await
+            .unwrap(),
+    );
+    assert_eq!(out.last().unwrap()["ck"], "z");
+}


### PR DESCRIPTION
## Problem

`exec_select` accepted the parsed `ORDER BY` and `LIMIT` clauses but bound them to `_order`/`_limit` and never used them. `SELECT ... ORDER BY x LIMIT 10` returned **every** matching row in unspecified order — a silent correctness violation and an unbounded result-size footgun.

## Fix

New `query::apply_order_and_limit` applied to SELECT results:

- **ORDER BY**: multi-key, ASC/DESC, numeric-aware comparison (so `2 < 10`), `NULLS FIRST/LAST` with the SQL-standard defaults (nulls last ascending, first descending).
- **LIMIT/OFFSET**: standard `LIMIT n [OFFSET m]` and the MySQL `LIMIT m, n` form; offset past the end yields empty rather than erroring.
- **Distributed reads**: the cluster layer applies the clauses *after* merging replica meta results, so cross-node queries honor them too (per-replica truncation before the LWW merge would be incorrect).
- Clause forms the engine cannot honor (`ORDER BY` arbitrary expressions, `LIMIT BY`, `WITH FILL`, `INTERPOLATE`) now return `QueryError::Unsupported` instead of being ignored.

## Tests

`tests/query_order_limit_test.rs`: ascending/descending, numeric ordering, multi-column sort with mixed directions, LIMIT truncation incl. `LIMIT 0`, OFFSET paging incl. past-the-end, missing-column rows sorting last, and rejection of unsupported ORDER BY expressions.

Found by codebase audit (medium severity: silent correctness violation).

https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9)_