### PR TITLE
Size SSTable bloom filters by entry count

### DIFF
--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -12,12 +12,24 @@ pub struct BloomProto {
     pub bits: Vec<bool>,
 }
 
+/// Bits allocated per expected key. With the two hash functions used below
+/// this yields a false-positive rate of roughly 3%.
+const BITS_PER_KEY: usize = 10;
+
+/// Lower bound on filter size so tiny tables still get a useful filter.
+const MIN_BITS: usize = 1024;
+
 impl BloomFilter {
     /// Create a new filter with `size` bits.
     pub fn new(size: usize) -> Self {
         Self {
-            bits: vec![false; size],
+            bits: vec![false; size.max(1)],
         }
+    }
+
+    /// Create a filter sized for the expected number of distinct keys.
+    pub fn with_capacity(expected_keys: usize) -> Self {
+        Self::new(expected_keys.saturating_mul(BITS_PER_KEY).max(MIN_BITS))
     }
 
     /// Compute two simple hash values for `item` using a pair of
@@ -38,6 +50,9 @@ impl BloomFilter {
 
     /// Record `item` in the filter.
     pub fn insert(&mut self, item: &str) {
+        if self.bits.is_empty() {
+            return;
+        }
         let (a, b) = self.hashes(item);
         self.bits[a] = true;
         self.bits[b] = true;
@@ -46,6 +61,11 @@ impl BloomFilter {
     /// Return `true` if the filter indicates that `item` may be present.
     /// False positives are possible but false negatives are not.
     pub fn may_contain(&self, item: &str) -> bool {
+        // An empty filter (e.g. decoded from a missing/corrupt proto) carries
+        // no information, so it must not rule anything out.
+        if self.bits.is_empty() {
+            return true;
+        }
         let (a, b) = self.hashes(item);
         self.bits.get(a).copied().unwrap_or(false) && self.bits.get(b).copied().unwrap_or(false)
     }

--- a/src/sstable.rs
+++ b/src/sstable.rs
@@ -75,7 +75,7 @@ impl SsTable {
         let path = path.into();
         let mut sorted = entries.to_vec();
         sorted.sort_by(|a, b| a.0.cmp(&b.0));
-        let mut bloom = BloomFilter::new(1024);
+        let mut bloom = BloomFilter::with_capacity(sorted.len());
         let mut zone_map = ZoneMap::default();
         let mut data = Vec::new();
         let mut index = Vec::new();
@@ -142,22 +142,26 @@ impl SsTable {
                 });
             }
         let raw = storage.get(&path).await?;
-        let mut bloom = BloomFilter::new(1024);
-        let mut zone_map = ZoneMap::default();
-        let mut index = Vec::new();
+        // First pass: collect keys and offsets so the bloom filter can be
+        // sized for the actual number of entries.
+        let mut keys: Vec<(&str, u64)> = Vec::new();
         let mut offset: u64 = 0;
-        let mut i = 0;
         for line in raw.split(|b| *b == NL).filter(|l| !l.is_empty()) {
             if let Some(pos) = line.iter().position(|b| *b == SEP) {
                 let key = std::str::from_utf8(&line[..pos])
                     .map_err(std::io::Error::other)?;
-                bloom.insert(key);
-                zone_map.update(key);
-                if i % INDEX_INTERVAL == 0 {
-                    index.push((key.to_string(), offset));
-                }
+                keys.push((key, offset));
                 offset += line.len() as u64 + 1; // include newline
-                i += 1;
+            }
+        }
+        let mut bloom = BloomFilter::with_capacity(keys.len());
+        let mut zone_map = ZoneMap::default();
+        let mut index = Vec::new();
+        for (i, (key, off)) in keys.iter().enumerate() {
+            bloom.insert(key);
+            zone_map.update(key);
+            if i % INDEX_INTERVAL == 0 {
+                index.push((key.to_string(), *off));
             }
         }
         Ok(Self {

--- a/tests/bloom_test.rs
+++ b/tests/bloom_test.rs
@@ -1,8 +1,47 @@
-use cass::bloom::BloomFilter;
+use cass::bloom::{BloomFilter, BloomProto};
 
 #[test]
 fn bloom_insert_check() {
     let mut b = BloomFilter::new(128);
     b.insert("hello");
     assert!(b.may_contain("hello"));
+}
+
+#[test]
+fn sized_filter_keeps_false_positive_rate_low() {
+    let n = 10_000;
+    let mut b = BloomFilter::with_capacity(n);
+    for i in 0..n {
+        b.insert(&format!("present-{i}"));
+    }
+    // no false negatives
+    for i in 0..n {
+        assert!(b.may_contain(&format!("present-{i}")));
+    }
+    // A fixed-size 1024-bit filter would saturate and report ~100% of
+    // absent keys as present; a properly sized filter stays far below that.
+    let false_positives = (0..1_000)
+        .filter(|i| b.may_contain(&format!("absent-{i}")))
+        .count();
+    assert!(
+        false_positives < 200,
+        "false positive rate too high: {false_positives}/1000"
+    );
+}
+
+#[test]
+fn empty_filter_from_proto_does_not_panic() {
+    // A corrupt or empty meta file can decode to a filter with no bits. It
+    // must not panic and must not rule out any keys (no false negatives).
+    let mut b = BloomFilter::from_proto(BloomProto { bits: Vec::new() });
+    assert!(b.may_contain("anything"));
+    b.insert("anything");
+    assert!(b.may_contain("anything"));
+}
+
+#[test]
+fn zero_size_filter_does_not_panic() {
+    let mut b = BloomFilter::new(0);
+    b.insert("a");
+    assert!(b.may_contain("a"));
 }

--- a/tests/sstable_test.rs
+++ b/tests/sstable_test.rs
@@ -23,3 +23,37 @@ async fn sstable_roundtrip() {
         .collect();
     assert_eq!(keys, vec!["a", "b", "c"]);
 }
+
+fn absent_key_false_positives(table: &SsTable) -> usize {
+    (0..1_000)
+        .filter(|i| table.bloom.may_contain(&format!("absent-{i}")))
+        .count()
+}
+
+#[tokio::test]
+async fn bloom_filter_scales_with_entry_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+    let entries: Vec<(String, Vec<u8>)> = (0..10_000)
+        .map(|i| (format!("key-{i:05}"), b"v".to_vec()))
+        .collect();
+    let table = SsTable::create("table", &entries, &storage).await.unwrap();
+
+    // With the previous fixed 1024-bit filter nearly every absent key was a
+    // false positive, defeating the filter entirely.
+    let fp = absent_key_false_positives(&table);
+    assert!(fp < 200, "bloom filter saturated: {fp}/1000 false positives");
+
+    // The rebuilt filter (load without a meta file) must be sized the same
+    // way.
+    std::fs::remove_file(dir.path().join("table.meta")).unwrap();
+    let reloaded = SsTable::load("table", &storage).await.unwrap();
+    for i in 0..10_000 {
+        assert!(reloaded.bloom.may_contain(&format!("key-{i:05}")));
+    }
+    let fp = absent_key_false_positives(&reloaded);
+    assert!(
+        fp < 200,
+        "rebuilt bloom filter saturated: {fp}/1000 false positives"
+    );
+}


### PR DESCRIPTION
## Problem

Bloom filters were a fixed 1024 bits regardless of how many keys an SSTable held. Any table beyond a few hundred entries saturated the filter, so `may_contain` returned true for nearly every absent key — the filter stopped pruning disk reads entirely, which is its only job.

## Fix

- `BloomFilter::with_capacity(expected_keys)`: 10 bits per key (~3% false-positive rate with the two hash functions used), 1024-bit floor.
- `SsTable::create` sizes the filter from the entry count; the meta-less rebuild path in `SsTable::load` counts entries in a first pass and sizes identically.
- Hardening: an empty bit vector (e.g. decoded from a corrupt/empty meta proto) previously hit a modulo-by-zero panic in `hashes()`; it now reports `may_contain = true` (no information ⇒ must not rule keys out) and `insert` is a no-op. `new(0)` is also guarded.

## Tests

- `sized_filter_keeps_false_positive_rate_low`: 10k keys, no false negatives, <20% FP on absent keys (the old fixed filter is ~100% here).
- `bloom_filter_scales_with_entry_count`: same property at the SSTable level, both freshly created and rebuilt without a meta file.
- `empty_filter_from_proto_does_not_panic`, `zero_size_filter_does_not_panic`.

Found by codebase audit (medium severity: bloom filter ineffective at scale + panic on corrupt meta).

https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9)_