### PR TITLE
Prune SSTable I/O in scan_ns with zone maps and the sparse index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,25 +288,22 @@ impl Database {
     /// merged together with later values (memtable/newer SSTables) overriding
     /// earlier ones. Returned entries are deduplicated and ordered by key.
     pub async fn scan_ns(&self, ns: &str) -> Vec<(String, Vec<u8>)> {
-        use base64::Engine;
         use std::collections::BTreeMap;
 
         let prefix = format!("{}:", ns);
         let mut map: BTreeMap<String, Vec<u8>> = BTreeMap::new();
 
-        // load from on-disk SSTables first so newer data overwrites older
+        // load from on-disk SSTables first so newer data overwrites older.
+        // scan_prefix consults the zone map and sparse index so tables (or
+        // file regions) that cannot contain this namespace are skipped
+        // instead of reading and decoding every file in full.
         let tables = self.sstables.read().await;
         for table in tables.iter() {
-            if let Ok(raw) = self.storage.get(&table.path).await {
-                for line in raw.split(|b| *b == b'\n').filter(|l| !l.is_empty()) {
-                    if let Some(pos) = line.iter().position(|b| *b == b'\t')
-                        && let Ok(key) = std::str::from_utf8(&line[..pos])
-                            && let Some(rest) = key.strip_prefix(&prefix)
-                                && let Ok(val) = base64::engine::general_purpose::STANDARD
-                                    .decode(&line[pos + 1..])
-                                {
-                                    map.insert(rest.to_string(), val);
-                                }
+            if let Ok(entries) = table.scan_prefix(&prefix, self.storage.as_ref()).await {
+                for (key, val) in entries {
+                    if let Some(rest) = key.strip_prefix(&prefix) {
+                        map.insert(rest.to_string(), val);
+                    }
                 }
             }
         }

--- a/src/sstable.rs
+++ b/src/sstable.rs
@@ -206,6 +206,67 @@ impl SsTable {
         Ok(None)
     }
 
+    /// Return all entries whose key starts with `prefix`.
+    ///
+    /// The zone map is consulted first so tables that cannot contain the
+    /// prefix are skipped without any I/O. The sparse index is then used to
+    /// start scanning near the first candidate line, and the scan stops as
+    /// soon as keys sort past the prefix range, so only the matching region
+    /// of the file is decoded.
+    pub async fn scan_prefix<S: Storage + Sync + Send + ?Sized>(
+        &self,
+        prefix: &str,
+        storage: &S,
+    ) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
+        if !self.zone_map.may_contain_prefix(prefix) {
+            return Ok(Vec::new());
+        }
+        let offset = self.seek_offset(prefix) as usize;
+        if let Some(root) = storage.local_path() {
+            let path = root.join(&self.path);
+            let file = File::open(path)?;
+            let mmap = unsafe { MmapOptions::new().map(&file)? };
+            let slice = mmap.get(offset..).unwrap_or(&mmap[..]);
+            return Self::collect_prefix(slice, prefix);
+        }
+        let raw = storage.get(&self.path).await?;
+        let slice = raw.get(offset..).unwrap_or(&raw[..]);
+        Self::collect_prefix(slice, prefix)
+    }
+
+    /// Scan sorted `key\tbase64(value)` lines collecting entries that start
+    /// with `prefix`, stopping at the first key sorting past the prefix.
+    fn collect_prefix(
+        mut slice: &[u8],
+        prefix: &str,
+    ) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
+        let mut out = Vec::new();
+        while !slice.is_empty() {
+            let Some(nl_pos) = slice.iter().position(|b| *b == NL) else {
+                break;
+            };
+            let line = &slice[..nl_pos];
+            slice = &slice[nl_pos + 1..];
+            let Some(pos) = line.iter().position(|b| *b == SEP) else {
+                continue;
+            };
+            let key_bytes = &line[..pos];
+            if key_bytes.starts_with(prefix.as_bytes()) {
+                let key = std::str::from_utf8(key_bytes)
+                    .map_err(std::io::Error::other)?
+                    .to_string();
+                let val = STANDARD
+                    .decode(&line[pos + 1..])
+                    .map_err(std::io::Error::other)?;
+                out.push((key, val));
+            } else if key_bytes > prefix.as_bytes() {
+                // sorted order: nothing past this point can match
+                break;
+            }
+        }
+        Ok(out)
+    }
+
     /// Perform a binary search over `lines` to find `key`.
     ///
     /// Each entry in `lines` must be of the form `key\tvalue` and the slice of

--- a/src/zonemap.rs
+++ b/src/zonemap.rs
@@ -41,6 +41,21 @@ impl ZoneMap {
         }
     }
 
+    /// Return `true` if any key starting with `prefix` could lie within the
+    /// stored bounds. When bounds are missing the function defaults to
+    /// `true` so as not to filter out potential matches.
+    pub fn may_contain_prefix(&self, prefix: &str) -> bool {
+        match (self.min.as_deref(), self.max.as_deref()) {
+            (Some(min), Some(max)) => {
+                // Keys with `prefix` form the interval [prefix, succ(prefix)).
+                // They cannot exist if every key sorts below the prefix, or
+                // if the smallest key already sorts past the whole interval.
+                !(max < prefix || (min > prefix && !min.starts_with(prefix)))
+            }
+            _ => true,
+        }
+    }
+
     /// Convert the zone map into a protobuf message.
     pub fn to_proto(&self) -> ZoneMapProto {
         ZoneMapProto {

--- a/tests/scan_prefix_test.rs
+++ b/tests/scan_prefix_test.rs
@@ -1,0 +1,141 @@
+use cass::{
+    Database, SqlEngine,
+    sstable::SsTable,
+    storage::{Storage, StorageError, local::LocalStorage},
+};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+/// Storage wrapper that counts reads of the table file and hides the local
+/// path so the remote-storage code path is exercised.
+struct CountingStorage {
+    inner: LocalStorage,
+    tbl_reads: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl Storage for CountingStorage {
+    async fn put(&self, path: &str, data: Vec<u8>) -> Result<(), StorageError> {
+        self.inner.put(path, data).await
+    }
+    async fn get(&self, path: &str) -> Result<Vec<u8>, StorageError> {
+        if path.ends_with(".tbl") || !path.contains('.') {
+            self.tbl_reads.fetch_add(1, Ordering::SeqCst);
+        }
+        self.inner.get(path).await
+    }
+    async fn append(&self, path: &str, data: &[u8]) -> Result<(), StorageError> {
+        self.inner.append(path, data).await
+    }
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
+        self.inner.list(prefix).await
+    }
+}
+
+#[tokio::test]
+async fn scan_prefix_returns_only_matching_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+    let entries = vec![
+        ("a:1".to_string(), b"v1".to_vec()),
+        ("a:2".to_string(), b"v2".to_vec()),
+        ("ab:1".to_string(), b"x".to_vec()),
+        ("b:1".to_string(), b"y".to_vec()),
+    ];
+    let table = SsTable::create("table", &entries, &storage).await.unwrap();
+
+    let got = table.scan_prefix("a:", &storage).await.unwrap();
+    assert_eq!(
+        got,
+        vec![
+            ("a:1".to_string(), b"v1".to_vec()),
+            ("a:2".to_string(), b"v2".to_vec()),
+        ]
+    );
+    assert!(table.scan_prefix("zz:", &storage).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn scan_prefix_skips_tables_outside_zone_map_without_io() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = CountingStorage {
+        inner: LocalStorage::new(dir.path()),
+        tbl_reads: AtomicUsize::new(0),
+    };
+    let entries = vec![
+        ("b:1".to_string(), b"v1".to_vec()),
+        ("b:2".to_string(), b"v2".to_vec()),
+    ];
+    let table = SsTable::create("table", &entries, &storage).await.unwrap();
+    storage.tbl_reads.store(0, Ordering::SeqCst);
+
+    // "a:" sorts entirely below the table's key range and "c:" entirely
+    // above; both must be answered from the zone map alone.
+    assert!(table.scan_prefix("a:", &storage).await.unwrap().is_empty());
+    assert!(table.scan_prefix("c:", &storage).await.unwrap().is_empty());
+    assert_eq!(
+        storage.tbl_reads.load(Ordering::SeqCst),
+        0,
+        "zone-map-excluded prefixes must not read the table file"
+    );
+
+    // A matching prefix still reads the file.
+    let got = table.scan_prefix("b:", &storage).await.unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(storage.tbl_reads.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn scan_ns_merges_sstables_and_memtable() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
+    let db = Database::new(storage, "wal.log").await.unwrap();
+    let engine = SqlEngine::new();
+    engine
+        .execute(&db, "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "CREATE TABLE other (id TEXT, val TEXT, PRIMARY KEY(id))")
+        .await
+        .unwrap();
+
+    // first generation, flushed to an SSTable
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('1', 'old')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('2', 'keep')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO other (id, val) VALUES ('9', 'zzz')")
+        .await
+        .unwrap();
+    db.flush().await.unwrap();
+
+    // second generation: overwrite one row in a newer SSTable
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('1', 'new')")
+        .await
+        .unwrap();
+    db.flush().await.unwrap();
+
+    // third generation stays in the memtable
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('3', 'mem')")
+        .await
+        .unwrap();
+
+    let rows = db.scan_ns("t").await;
+    let keys: Vec<&str> = rows.iter().map(|(k, _)| k.as_str()).collect();
+    assert_eq!(keys, vec!["1", "2", "3"]);
+    // newer SSTable wins over older
+    let v1 = &rows[0].1;
+    assert!(String::from_utf8_lossy(&v1[8..]).contains("new"));
+    // rows from the other namespace are not included
+    assert!(!keys.contains(&"9"));
+}


### PR DESCRIPTION
## Problem

`Database::scan_ns` read every SSTable file **in full** from storage and walked every line for any namespace scan. Partial-key SELECTs and COUNTs therefore cost O(total data across all tables) no matter which table they touched — and on the S3 backend that meant downloading every object per query.

## Fix

New `SsTable::scan_prefix(prefix, storage)`:

- **Zone map pruning**: `ZoneMap::may_contain_prefix` rules out tables whose `[min, max]` key range cannot intersect the prefix interval `[prefix, succ(prefix))` — answered with zero I/O.
- **Sparse index seek**: scanning starts at the index entry at or before the prefix instead of byte 0.
- **Sorted early exit**: the scan stops at the first key sorting past the prefix range.
- Local storage reads through a mmap instead of loading the whole file into memory.

`scan_ns` delegates to it; merge semantics (oldest table → newest, memtable overlay last) are unchanged.

## Tests

- `scan_prefix_returns_only_matching_entries` (incl. the `ab:` vs `a:` boundary).
- `scan_prefix_skips_tables_outside_zone_map_without_io`: a counting storage wrapper proves zone-map-excluded prefixes perform **zero** table reads.
- `scan_ns_merges_sstables_and_memtable`: end-to-end merge behavior across two flushed generations plus the memtable, with namespace isolation.

Found by codebase audit (medium severity: O(total data) reads on the partial-key query path).

https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9)_