### PR TITLE
Fan out LWT replica RPCs concurrently

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -886,74 +886,76 @@ impl Cluster {
         };
         let ballot = (ts << 16) | (salt & 0xffff);
 
-        // Prepare phase
+        // Prepare phase: contact all replicas concurrently so latency is
+        // bounded by the slowest replica rather than the sum of round trips.
+        let prepare_results = join_all(healthy.iter().map(|node| {
+            let ns = ns.clone();
+            let key = key.clone();
+            async move {
+                if node == &self.self_addr {
+                    self.lwt_prepare(&ns, &key, ballot).await
+                } else if let Ok(mut client) = self.grpc_client(node).await
+                    && let Ok(resp) = client
+                        .lwt_prepare(tonic::Request::new(LwtPrepareRequest {
+                            namespace: ns,
+                            key,
+                            ballot,
+                        }))
+                        .await
+                {
+                    let r = resp.into_inner();
+                    (r.promised, r.ballot, r.value)
+                } else {
+                    (false, 0, Vec::new())
+                }
+            }
+        }))
+        .await;
         let mut promised = 0usize;
         let mut max_accepted_ballot = 0u64;
         let mut max_accepted_value: Vec<u8> = Vec::new();
-        for node in &healthy {
-            if node == &self.self_addr {
-                let (ok, acc_b, acc_v) = self.lwt_prepare(&ns, &key, ballot).await;
-                if ok {
-                    promised += 1;
-                    if acc_b > max_accepted_ballot {
-                        max_accepted_ballot = acc_b;
-                        max_accepted_value = acc_v;
-                    }
+        for (ok, acc_b, acc_v) in prepare_results {
+            if ok {
+                promised += 1;
+                if acc_b > max_accepted_ballot {
+                    max_accepted_ballot = acc_b;
+                    max_accepted_value = acc_v;
                 }
-            } else if let Ok(mut client) = self.grpc_client(node).await
-                && let Ok(resp) = client
-                    .lwt_prepare(tonic::Request::new(LwtPrepareRequest {
-                        namespace: ns.clone(),
-                        key: key.clone(),
-                        ballot,
-                    }))
-                    .await
-                {
-                    let r = resp.into_inner();
-                    if r.promised {
-                        promised += 1;
-                        if r.ballot > max_accepted_ballot {
-                            max_accepted_ballot = r.ballot;
-                            max_accepted_value = r.value;
-                        }
-                    }
-                }
+            }
         }
         if promised < required {
             return Err(QueryError::Other("not enough healthy replicas".into()));
         }
 
-        // Read phase
-        let mut read_ballot = max_accepted_ballot;
-        let mut read_value = max_accepted_value.clone();
-        for node in &healthy {
-            if node == &self.self_addr {
-                let (b, v) = self.lwt_read(&ns, &key).await;
-                if b > read_ballot
-                    || (b == 0 && read_ballot == 0 && read_value.is_empty() && !v.is_empty())
-                {
-                    read_ballot = b;
-                    read_value = v;
-                }
-            } else if let Ok(mut client) = self.grpc_client(node).await
-                && let Ok(resp) = client
-                    .lwt_read(tonic::Request::new(LwtReadRequest {
-                        namespace: ns.clone(),
-                        key: key.clone(),
-                    }))
-                    .await
+        // Read phase (concurrent fan-out, results merged sequentially)
+        let read_results = join_all(healthy.iter().map(|node| {
+            let ns = ns.clone();
+            let key = key.clone();
+            async move {
+                if node == &self.self_addr {
+                    Some(self.lwt_read(&ns, &key).await)
+                } else if let Ok(mut client) = self.grpc_client(node).await
+                    && let Ok(resp) = client
+                        .lwt_read(tonic::Request::new(LwtReadRequest { namespace: ns, key }))
+                        .await
                 {
                     let r = resp.into_inner();
-                    if r.ballot > read_ballot
-                        || (r.ballot == 0
-                            && read_ballot == 0
-                            && read_value.is_empty()
-                            && !r.value.is_empty())
-                    {
-                        read_ballot = r.ballot;
-                        read_value = r.value;
-                    }
+                    Some((r.ballot, r.value))
+                } else {
+                    None
                 }
+            }
+        }))
+        .await;
+        let mut read_ballot = max_accepted_ballot;
+        let mut read_value = max_accepted_value.clone();
+        for (b, v) in read_results.into_iter().flatten() {
+            if b > read_ballot
+                || (b == 0 && read_ballot == 0 && read_value.is_empty() && !v.is_empty())
+            {
+                read_ballot = b;
+                read_value = v;
+            }
         }
 
         // Evaluate condition and build proposed value
@@ -1013,47 +1015,56 @@ impl Cluster {
             _ => return Err(QueryError::Unsupported),
         };
 
-        // Propose phase
-        let mut accepted = 0usize;
-        for node in &healthy {
-            if node == &self.self_addr {
-                if self
-                    .lwt_propose(&ns, &key, ballot, proposed_value.clone())
-                    .await
+        // Propose phase (concurrent fan-out)
+        let propose_results = join_all(healthy.iter().map(|node| {
+            let ns = ns.clone();
+            let key = key.clone();
+            let value = proposed_value.clone();
+            async move {
+                if node == &self.self_addr {
+                    self.lwt_propose(&ns, &key, ballot, value).await
+                } else if let Ok(mut client) = self.grpc_client(node).await
+                    && let Ok(resp) = client
+                        .lwt_propose(tonic::Request::new(LwtProposeRequest {
+                            namespace: ns,
+                            key,
+                            ballot,
+                            value,
+                        }))
+                        .await
                 {
-                    accepted += 1;
+                    resp.into_inner().accepted
+                } else {
+                    false
                 }
-            } else if let Ok(mut client) = self.grpc_client(node).await
-                && let Ok(resp) = client
-                    .lwt_propose(tonic::Request::new(LwtProposeRequest {
-                        namespace: ns.clone(),
-                        key: key.clone(),
-                        ballot,
-                        value: proposed_value.clone(),
-                    }))
-                    .await
-                    && resp.into_inner().accepted {
-                        accepted += 1;
-                    }
-        }
+            }
+        }))
+        .await;
+        let accepted = propose_results.into_iter().filter(|ok| *ok).count();
         if accepted < required {
             return Err(QueryError::Other("not enough healthy replicas".into()));
         }
 
-        // Commit phase (best effort to all healthy replicas)
-        for node in &healthy {
-            if node == &self.self_addr {
-                self.lwt_commit(&ns, &key, proposed_value.clone()).await;
-            } else if let Ok(mut client) = self.grpc_client(node).await {
-                let _ = client
-                    .lwt_commit(tonic::Request::new(LwtCommitRequest {
-                        namespace: ns.clone(),
-                        key: key.clone(),
-                        value: proposed_value.clone(),
-                    }))
-                    .await;
+        // Commit phase (best effort to all healthy replicas, concurrently)
+        join_all(healthy.iter().map(|node| {
+            let ns = ns.clone();
+            let key = key.clone();
+            let value = proposed_value.clone();
+            async move {
+                if node == &self.self_addr {
+                    self.lwt_commit(&ns, &key, value).await;
+                } else if let Ok(mut client) = self.grpc_client(node).await {
+                    let _ = client
+                        .lwt_commit(tonic::Request::new(LwtCommitRequest {
+                            namespace: ns,
+                            key,
+                            value,
+                        }))
+                        .await;
+                }
             }
-        }
+        }))
+        .await;
 
         // Build LWT response row
         let mut row = BTreeMap::new();

--- a/tests/cluster_lwt_test.rs
+++ b/tests/cluster_lwt_test.rs
@@ -79,6 +79,41 @@ async fn execute_lwt_insert_and_update_paths() {
 }
 
 #[tokio::test]
+async fn concurrent_lwt_inserts_apply_exactly_once() {
+    let addr = "http://127.0.0.1:6300";
+    let cluster = Arc::new(build_cluster(1, addr).await);
+    cluster
+        .execute(
+            "CREATE TABLE kv (id TEXT, val TEXT, PRIMARY KEY(id))",
+            false,
+            0,
+        )
+        .await
+        .unwrap();
+
+    // Fire a batch of competing IF NOT EXISTS inserts for the same key in
+    // parallel; the Paxos rounds now fan out to replicas concurrently and
+    // exactly one contender may win.
+    let mut handles = Vec::new();
+    for i in 0..8 {
+        let c = cluster.clone();
+        handles.push(tokio::spawn(async move {
+            let sql = format!("INSERT INTO kv (id, val) VALUES ('race','{i}') IF NOT EXISTS");
+            c.execute(&sql, false, 0).await
+        }));
+    }
+    let mut wins = 0usize;
+    for h in handles {
+        if let Ok(Ok(resp)) = h.await
+            && applied(&resp) == Some("true".to_string())
+        {
+            wins += 1;
+        }
+    }
+    assert_eq!(wins, 1, "exactly one concurrent LWT insert may be applied");
+}
+
+#[tokio::test]
 async fn execute_lwt_errors_when_insufficient_replicas() {
     let addr = "http://127.0.0.1:6200";
     let cluster = build_cluster(2, addr).await; // rf=2 but only one node present


### PR DESCRIPTION
## Problem

The prepare, read, propose, and commit phases of `Cluster::execute_lwt` each awaited replicas one at a time inside a `for` loop, so every Paxos round cost the **sum** of all replica round-trip times — four times over per transaction. One slow or distant replica stalled every lightweight transaction on the coordinator.

## Fix

Each phase now issues its RPCs to all replicas concurrently via `futures::future::join_all` and merges the results afterwards, bounding per-phase latency by the slowest replica instead of the sum. Quorum accounting, ballot comparison, and the LWW read-merge rules are byte-for-byte unchanged — only the await structure moved.

## Tests

- New `concurrent_lwt_inserts_apply_exactly_once`: 8 competing `IF NOT EXISTS` inserts for the same key fired in parallel; exactly one may win.
- Existing LWT coverage (`lwt_test`, `cluster_lwt_test`, `lwt_orders_test`, `replication_grpc_test` — including multi-node gRPC paths and the insufficient-replica error case) all pass unchanged.

Found by codebase audit (medium severity: per-replica latency summing on the LWT hot path).

https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9)_