### PR TITLE
Surface row codec errors instead of silently returning empty rows

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -966,7 +966,7 @@ impl Cluster {
                     applied = true;
                     let (_schema, row_map) = insert_row_values.unwrap();
                     let mut buf = ts.to_be_bytes().to_vec();
-                    buf.extend_from_slice(&crate::schema::encode_row(&row_map));
+                    buf.extend_from_slice(&crate::schema::encode_row(&row_map)?);
                     buf
                 } else {
                     Vec::new()
@@ -974,7 +974,7 @@ impl Cluster {
             }
             (Statement::Update { .. }, _) => {
                 let data = Self::split_ts(&read_value).1;
-                let mut current = crate::schema::decode_row(data);
+                let mut current = crate::schema::decode_row(data)?;
                 if !lwt_equals.is_empty() {
                     let success = lwt_equals
                         .iter()
@@ -1002,7 +1002,7 @@ impl Cluster {
                             }
                         }
                         let mut buf = ts.to_be_bytes().to_vec();
-                        buf.extend_from_slice(&crate::schema::encode_row(&current));
+                        buf.extend_from_slice(&crate::schema::encode_row(&current)?);
                         buf
                     }
                 } else {
@@ -1063,7 +1063,7 @@ impl Cluster {
         );
         if !applied && !lwt_equals.is_empty() {
             let data = Self::split_ts(&read_value).1;
-            let current = crate::schema::decode_row(data);
+            let current = crate::schema::decode_row(data)?;
             for (k, _) in lwt_equals.iter() {
                 if let Some(v) = current.get(k.as_str()) {
                     row.insert(k.clone(), v.clone());
@@ -1450,7 +1450,15 @@ impl Cluster {
             .filter(|n| !unhealthy.contains(n))
             .collect();
         for (key, (ts, val)) in latest {
-            let mut row_map = decode_row(val.as_bytes());
+            // Read repair is best effort: a corrupt replica value must not
+            // abort repair of the remaining keys.
+            let mut row_map = match decode_row(val.as_bytes()) {
+                Ok(map) => map,
+                Err(e) => {
+                    tracing::warn!(key = %key, "skipping read repair for undecodable row: {e}");
+                    continue;
+                }
+            };
             for (col, part) in schema.key_columns().iter().zip(key.split('|')) {
                 row_map.insert(col.clone(), part.to_string());
             }
@@ -1604,8 +1612,7 @@ impl Cluster {
         if !rows.is_empty() || !arr_rows.is_empty() {
             for (_k, (_ts, val)) in rows {
                 if !val.is_empty() {
-                    let map = decode_row(val.as_bytes());
-                    arr_rows.push(map);
+                    arr_rows.push(decode_row(val.as_bytes())?);
                 }
             }
             return Ok(output_to_proto(QueryOutput::Rows(arr_rows)));

--- a/src/query.rs
+++ b/src/query.rs
@@ -108,6 +108,9 @@ pub enum QueryError {
     /// The query is syntactically valid but not supported by the engine.
     #[error("unsupported query")]
     Unsupported,
+    /// A stored row could not be serialized or deserialized.
+    #[error(transparent)]
+    Codec(#[from] crate::schema::RowCodecError),
     /// Any other internal or I/O error.
     #[error("{0}")]
     Other(String),
@@ -437,7 +440,9 @@ impl SqlEngine {
                 return Err(QueryError::Unsupported);
             }
             let row = values.rows.first().ok_or(QueryError::Unsupported)?;
-            let (key, data) = build_row(schema_ref, &cols, row).ok_or(QueryError::Unsupported)?;
+            let (key, row_map) =
+                build_row(schema_ref, &cols, row).ok_or(QueryError::Unsupported)?;
+            let data = encode_row(&row_map)?;
             let applied = db.insert_ns_if_absent_ts(&ns, key, data, ts).await;
             let mut row = BTreeMap::new();
             row.insert("[applied]".to_string(), applied.to_string());
@@ -445,8 +450,9 @@ impl SqlEngine {
         } else {
             let mut count = 0;
             for row in &values.rows {
-                let (key, data) =
+                let (key, row_map) =
                     build_row(schema_ref, &cols, row).ok_or(QueryError::Unsupported)?;
+                let data = encode_row(&row_map)?;
                 db.insert_ns_ts(&ns, key, data, ts)
                     .await
                     .map_err(|e| QueryError::Other(e.to_string()))?;
@@ -481,7 +487,7 @@ impl SqlEngine {
         let key = build_single_key(schema_ref, &cond_map).ok_or(QueryError::Unsupported)?;
         let mut row_map = if let Some(bytes) = db.get_ns(&ns, &key).await {
             let (_, data) = split_ts(&bytes);
-            decode_row(data)
+            decode_row(data)?
         } else {
             BTreeMap::new()
         };
@@ -524,7 +530,7 @@ impl SqlEngine {
                     row_map.insert(col, val);
                 }
         }
-        let data = encode_row(&row_map);
+        let data = encode_row(&row_map)?;
         db.insert_ns_ts(&ns, key, data, ts)
             .await
             .map_err(|e| QueryError::Other(e.to_string()))?;
@@ -633,7 +639,7 @@ impl SqlEngine {
             if let Some(bytes) = db.get_ns(ns, &key).await {
                 let (_, data) = split_ts(&bytes);
                 if !data.is_empty() {
-                    let mut row_map = decode_row(data);
+                    let mut row_map = decode_row(data)?;
                     for col in schema.key_columns() {
                         if let Some(v) = cond_map.get(&col) {
                             row_map.insert(col, v.clone());
@@ -654,7 +660,7 @@ impl SqlEngine {
                 if data.is_empty() {
                     continue;
                 }
-                let mut row_map = decode_row(data);
+                let mut row_map = decode_row(data)?;
                 for (col, part) in schema.key_columns().iter().zip(k.split('|')) {
                     row_map.insert(col.clone(), part.to_string());
                 }
@@ -714,13 +720,13 @@ impl SqlEngine {
                         }
                         continue;
                     }
-                    let mut row_map = decode_row(data);
+                    let mut row_map = decode_row(data)?;
                     for (col, part) in key_cols.iter().zip(key.split('|')) {
                         row_map.insert(col.clone(), part.to_string());
                     }
                     let sel_map = project_row(&row_map, &cols, wildcard);
                     if meta {
-                        let val = String::from_utf8_lossy(&encode_row(&sel_map)).into_owned();
+                        let val = String::from_utf8_lossy(&encode_row(&sel_map)?).into_owned();
                         meta_rows.push((key.clone(), ts, val));
                     } else {
                         out_rows.push(sel_map);
@@ -742,7 +748,7 @@ impl SqlEngine {
                             }
                             break;
                         }
-                        let mut row_map = decode_row(data);
+                        let mut row_map = decode_row(data)?;
                         for (col, part) in key_cols.iter().zip(k.split('|')) {
                             row_map.insert(col.clone(), part.to_string());
                         }
@@ -753,7 +759,7 @@ impl SqlEngine {
                             let sel_map = project_row(&row_map, &cols, wildcard);
                             if meta {
                                 let val =
-                                    String::from_utf8_lossy(&encode_row(&sel_map)).into_owned();
+                                    String::from_utf8_lossy(&encode_row(&sel_map)?).into_owned();
                                 meta_rows.push((k.clone(), ts, val));
                             } else {
                                 out_rows.push(sel_map);
@@ -1105,8 +1111,12 @@ fn extract_partition_key(schema: &TableSchema, cols: &[String], row: &[Expr]) ->
     }
 }
 
-/// Build the full key and encoded row data from an insert row.
-fn build_row(schema: &TableSchema, cols: &[String], row: &[Expr]) -> Option<(String, Vec<u8>)> {
+/// Build the full key and row column map from an insert row.
+fn build_row(
+    schema: &TableSchema,
+    cols: &[String],
+    row: &[Expr],
+) -> Option<(String, BTreeMap<String, String>)> {
     if cols.len() != row.len() {
         return None;
     }
@@ -1120,7 +1130,7 @@ fn build_row(schema: &TableSchema, cols: &[String], row: &[Expr]) -> Option<(Str
             data_map.insert(col.clone(), val);
         }
     }
-    Some((key_parts.join("|"), encode_row(&data_map)))
+    Some((key_parts.join("|"), data_map))
 }
 
 /// Build partition key strings from column values, generating all combinations.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,12 +33,48 @@ impl TableSchema {
     }
 }
 
+/// Error produced when serializing or deserializing a row.
+#[derive(thiserror::Error, Debug)]
+#[error("row codec: {0}")]
+pub struct RowCodecError(#[from] serde_json::Error);
+
 /// Serialize a row map into bytes.
-pub fn encode_row(map: &BTreeMap<String, String>) -> Vec<u8> {
-    serde_json::to_vec(map).unwrap_or_default()
+pub fn encode_row(map: &BTreeMap<String, String>) -> Result<Vec<u8>, RowCodecError> {
+    Ok(serde_json::to_vec(map)?)
 }
 
-/// Deserialize row bytes into a map. Missing or invalid data yields an empty map.
-pub fn decode_row(data: &[u8]) -> BTreeMap<String, String> {
-    serde_json::from_slice(data).unwrap_or_default()
+/// Deserialize row bytes into a map.
+///
+/// Empty input is a valid representation of an absent/deleted row and yields
+/// an empty map. Non-empty data that fails to parse is corruption and is
+/// surfaced as an error rather than silently treated as an empty row.
+pub fn decode_row(data: &[u8]) -> Result<BTreeMap<String, String>, RowCodecError> {
+    if data.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    Ok(serde_json::from_slice(data)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_roundtrip() {
+        let mut map = BTreeMap::new();
+        map.insert("a".to_string(), "1".to_string());
+        let bytes = encode_row(&map).unwrap();
+        assert_eq!(decode_row(&bytes).unwrap(), map);
+    }
+
+    #[test]
+    fn empty_input_is_empty_row() {
+        assert!(decode_row(b"").unwrap().is_empty());
+    }
+
+    #[test]
+    fn corrupt_input_is_an_error_not_an_empty_row() {
+        assert!(decode_row(b"{not json").is_err());
+        assert!(decode_row(&[0xff, 0xfe]).is_err());
+    }
 }

--- a/tests/row_codec_test.rs
+++ b/tests/row_codec_test.rs
@@ -1,0 +1,67 @@
+use cass::{
+    Database, SqlEngine,
+    query::QueryOutput,
+    storage::{Storage, local::LocalStorage},
+};
+use std::sync::Arc;
+
+async fn setup() -> (Database, SqlEngine) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage: Arc<dyn Storage> = Arc::new(LocalStorage::new(dir.path()));
+    // keep the tempdir alive for the duration of the test
+    std::mem::forget(dir);
+    let db = Database::new(storage, "wal.log").await.unwrap();
+    (db, SqlEngine::new())
+}
+
+#[tokio::test]
+async fn corrupt_row_surfaces_error_instead_of_empty_row() {
+    let (db, engine) = setup().await;
+    engine
+        .execute(&db, "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('1', 'a')")
+        .await
+        .unwrap();
+
+    // Overwrite the stored row with bytes that are not valid JSON,
+    // simulating on-disk corruption.
+    db.insert_ns("t", "1".to_string(), b"{not json".to_vec())
+        .await
+        .unwrap();
+
+    let res = engine.execute(&db, "SELECT * FROM t WHERE id = '1'").await;
+    assert!(
+        res.is_err(),
+        "corrupt row data must produce an error, not a silently empty row"
+    );
+}
+
+#[tokio::test]
+async fn deleted_row_still_reads_as_absent() {
+    let (db, engine) = setup().await;
+    engine
+        .execute(&db, "CREATE TABLE t (id TEXT, val TEXT, PRIMARY KEY(id))")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO t (id, val) VALUES ('1', 'a')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "DELETE FROM t WHERE id = '1'")
+        .await
+        .unwrap();
+
+    // A tombstone (empty payload) is a legitimate empty row, not corruption.
+    match engine
+        .execute(&db, "SELECT * FROM t WHERE id = '1'")
+        .await
+        .unwrap()
+    {
+        QueryOutput::Rows(rows) => assert!(rows.is_empty()),
+        _ => panic!("expected row output"),
+    }
+}


### PR DESCRIPTION
## Problem

`encode_row`/`decode_row` swallowed serde_json errors with `unwrap_or_default()`, so a corrupted stored row decoded to an empty map — indistinguishable from a legitimately deleted row. On-disk corruption surfaced as silent data loss ("all columns gone") instead of an error anyone could detect.

## Fix

- Both functions return `Result<_, RowCodecError>` (new error type in `schema.rs`).
- **Empty input remains a valid empty row** — tombstones and absent rows are not corruption and keep working exactly as before. Only *non-empty* data that fails to parse is an error.
- `QueryError` gains a transparent `Codec` variant; the query engine and the cluster LWT paths propagate it.
- Read repair, which is best-effort, logs and skips an undecodable replica value rather than aborting the whole repair pass.
- `build_row` now returns the column map and callers encode it, so encode failures propagate there too.

## Tests

- `corrupt_row_surfaces_error_instead_of_empty_row`: garbage bytes in a stored row turn a SELECT into an error, not an empty result.
- `deleted_row_still_reads_as_absent`: tombstone behavior unchanged.
- Unit tests for round-trip, empty-input, and corrupt-input cases.

Found by codebase audit (medium severity: corruption masked as silent data loss).

https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJXWjB9ERGgV6B9mRqrdM9)_